### PR TITLE
Make sure commands folder is in sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     maintainer_email='847671011@qq.com',
     keywords=['Redis', 'key-value store', 'asyncio'],
     license='MIT',
-    packages=['aredis'],
+    packages=['aredis', 'aredis.commands'],
     tests_require=['pytest',
                    'pytest_asyncio'],
     cmdclass={'test': PyTest},


### PR DESCRIPTION
While #12 fixed installing the packages it did not fix the underlying problem. It seems the `commands` folder was never inserted into the the sdist send to pypi. This simple pull request should fix that. 