### PR TITLE
Allow setting the loop event as an argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,19 @@ to the official command syntax. There are a few exceptions:
   track of the cursor while iterating. (Use Python 3.6 and the scan_iter/sscan_iter/hscan_iter/zscan_iter
   methods for this behavior. **iter functions are not supported in Python 3.5**)
 
+Loop
+^^^^
+
+The event loop can be set with the loop keyworkd argugment. If no loop is given
+the default event loop will be used.
+
+.. code-block:: python
+
+    >>> import aredis
+    >>> import asyncio
+    >>> loop = asyncio.get_event_loop()
+    >>> r = aredis.StrictRedis(host='localhost', port=6379, db=0, loop=loop)
+
 Connections
 ^^^^^^^^^^^
 

--- a/aredis/client.py
+++ b/aredis/client.py
@@ -87,7 +87,8 @@ class StrictRedis(*mixins):
                  unix_socket_path=None,
                  ssl=False, ssl_keyfile=None, ssl_certfile=None,
                  ssl_cert_reqs=None, ssl_ca_certs=None,
-                 max_connections=None, retry_on_timeout=False):
+                 max_connections=None, retry_on_timeout=False,
+                 *, loop=None):
         if not connection_pool:
             kwargs = {
                 'db': db,
@@ -95,7 +96,8 @@ class StrictRedis(*mixins):
                 'stream_timeout': stream_timeout,
                 'connect_timeout': connect_timeout,
                 'max_connections': max_connections,
-                'retry_on_timeout': retry_on_timeout
+                'retry_on_timeout': retry_on_timeout,
+                'loop': loop
             }
             # based on input, setup appropriate connection args
             if unix_socket_path is not None:

--- a/aredis/lock.py
+++ b/aredis/lock.py
@@ -99,6 +99,7 @@ class Lock(object):
         wait trying to acquire the lock.
         """
         sleep = self.sleep
+        pool = self.redis.connection_pool
         token = b(uuid.uuid1().hex)
         if blocking is None:
             blocking = self.blocking
@@ -115,7 +116,7 @@ class Lock(object):
                 return False
             if stop_trying_at is not None and mod_time.time() > stop_trying_at:
                 return False
-            await asyncio.sleep(sleep)
+            await asyncio.sleep(sleep, loop=pool.get_connection().loop)
 
     async def do_acquire(self, token):
         if await self.redis.setnx(self.name, token):

--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -249,7 +249,7 @@ class PubSub(object):
         for pattern, handler in iteritems(self.patterns):
             if handler is None:
                 raise PubSubError("Pattern: '%s' has no handler registered")
-        loop = asyncio.get_event_loop()
+        loop = self.connection.loop
         thread = PubSubWorkerThread(self, loop, daemon=daemon)
         thread.start()
         return thread

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     license='MIT',
     packages=['aredis', 'aredis.commands'],
     tests_require=['pytest',
-                   'pytest_asyncio'],
+                   'pytest_asyncio>=0.5.0'],
     cmdclass={'test': PyTest},
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,54 +49,54 @@ class AsyncMock(Mock):
         super(AsyncMock, self).__init__(*args, **kwargs)
 
     def __await__(self):
-        future = asyncio.Future()
+        future = asyncio.Future(loop=self.loop)
         future.set_result(self)
         result = yield from future
         return result
 
     @staticmethod
-    def pack_response(response):
-        future = asyncio.Future()
+    def pack_response(response, *, loop):
+        future = asyncio.Future(loop=loop)
         future.set_result(response)
         return future
 
 
-def _gen_cluster_mock_resp(r, response):
-    mock_connection_pool = AsyncMock()
-    connection = AsyncMock()
-    connection.read_response.return_value = AsyncMock.pack_response(response)
+def _gen_cluster_mock_resp(r, response, *, loop):
+    mock_connection_pool = AsyncMock(loop=loop)
+    connection = AsyncMock(loop=loop)
+    connection.read_response.return_value = AsyncMock.pack_response(response, loop=loop)
     mock_connection_pool.get_connection.return_value = connection
     r.connection_pool = mock_connection_pool
     return r
 
 
 @pytest.fixture()
-def mock_cluster_resp_ok():
-    r = aredis.StrictRedis()
-    return _gen_cluster_mock_resp(r, b'OK')
+def mock_cluster_resp_ok(event_loop):
+    r = aredis.StrictRedis(loop=event_loop)
+    return _gen_cluster_mock_resp(r, b'OK', loop=event_loop)
 
 
 @pytest.fixture()
-def mock_cluster_resp_int():
-    r = aredis.StrictRedis()
-    return _gen_cluster_mock_resp(r, b'2')
+def mock_cluster_resp_int(event_loop):
+    r = aredis.StrictRedis(loop=event_loop)
+    return _gen_cluster_mock_resp(r, b'2', loop=event_loop)
 
 
 @pytest.fixture()
-def mock_cluster_resp_info():
-    r = aredis.StrictRedis()
+def mock_cluster_resp_info(event_loop):
+    r = aredis.StrictRedis(loop=event_loop)
     response = (b'cluster_state:ok\r\ncluster_slots_assigned:16384\r\n'
                 b'cluster_slots_ok:16384\r\ncluster_slots_pfail:0\r\n'
                 b'cluster_slots_fail:0\r\ncluster_known_nodes:7\r\n'
                 b'cluster_size:3\r\ncluster_current_epoch:7\r\n'
                 b'cluster_my_epoch:2\r\ncluster_stats_messages_sent:170262\r\n'
                 b'cluster_stats_messages_received:105653\r\n')
-    return _gen_cluster_mock_resp(r, response)
+    return _gen_cluster_mock_resp(r, response, loop=event_loop)
 
 
 @pytest.fixture()
-def mock_cluster_resp_nodes():
-    r = aredis.StrictRedis()
+def mock_cluster_resp_nodes(event_loop):
+    r = aredis.StrictRedis(loop=event_loop)
     response = (b'c8253bae761cb1ecb2b61857d85dfe455a0fec8b 172.17.0.7:7006 '
                 b'slave aa90da731f673a99617dfe930306549a09f83a6b 0 '
                 b'1447836263059 5 connected\n'
@@ -114,13 +114,13 @@ def mock_cluster_resp_nodes():
                 b'fbb23ed8cfa23f17eaf27ff7d0c410492a1093d6 172.17.0.7:7002 '
                 b'master,fail - 1447829446956 1447829444948 1 disconnected\n'
                 )
-    return _gen_cluster_mock_resp(r, response)
+    return _gen_cluster_mock_resp(r, response, loop=event_loop)
 
 
 @pytest.fixture()
-def mock_cluster_resp_slaves():
-    r = aredis.StrictRedis()
+def mock_cluster_resp_slaves(event_loop):
+    r = aredis.StrictRedis(loop=event_loop)
     response = (b"['1df047e5a594f945d82fc140be97a1452bcbf93e 172.17.0.7:7007 "
                 b"slave 19efe5a631f3296fdf21a5441680f893e8cc96ec 0 "
                 b"1447836789290 3 connected']")
-    return _gen_cluster_mock_resp(r, response)
+    return _gen_cluster_mock_resp(r, response, loop=event_loop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,8 +39,8 @@ def skip_python_vsersion_lt(min_version):
 
 
 @pytest.fixture()
-def r():
-    return aredis.StrictRedis()
+def r(event_loop):
+    return aredis.StrictRedis(loop=event_loop)
 
 
 class AsyncMock(Mock):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -27,7 +27,7 @@ async def redis_server_time(client):
 class TestResponseCallbacks(object):
     "Tests for the response callback system"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_response_callbacks(self, r):
         assert r.response_callbacks == aredis.StrictRedis.RESPONSE_CALLBACKS
         assert id(r.response_callbacks) != id(aredis.StrictRedis.RESPONSE_CALLBACKS)
@@ -38,7 +38,7 @@ class TestResponseCallbacks(object):
 
 class TestRedisCommands(object):
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_command_on_invalid_key_type(self, r):
         await r.flushdb()
         await r.lpush('a', '1')
@@ -46,41 +46,41 @@ class TestRedisCommands(object):
             await r.get('a')
 
     # SERVER INFORMATION
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_client_list(self, r):
         clients = await r.client_list()
         assert isinstance(clients[0], dict)
         assert 'addr' in clients[0]
 
     @skip_if_server_version_lt('2.6.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_client_getname(self, r):
         assert await r.client_getname() is None
 
     @skip_if_server_version_lt('2.6.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_client_setname(self, r):
         assert await r.client_setname('redis_py_test')
         assert await r.client_getname() == 'redis_py_test'
 
     @skip_if_server_version_lt('2.9.5')
-    @pytest.mark.asyncio
-    async def test_client_pause(self, r):
+    @pytest.mark.asyncio(forbid_global_loop=True)
+    async def test_client_pause(self, r, event_loop):
         await r.flushdb()
         key = 'key_should_expire'
-        another_client = aredis.StrictRedis()
+        another_client = aredis.StrictRedis(loop=event_loop)
         await r.set(key, 1, px=100)
         assert await r.client_pause(100)
         res = await another_client.get(key)
         assert not res
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_config_get(self, r):
         data = await r.config_get()
         assert 'maxmemory' in data
         assert data['maxmemory'].isdigit()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_config_resetstat(self, r):
         await r.ping()
         prior_commands_processed = int((await r.info())['total_commands_processed'])
@@ -89,7 +89,7 @@ class TestRedisCommands(object):
         reset_commands_processed = int((await r.info())['total_commands_processed'])
         assert reset_commands_processed < prior_commands_processed
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_config_set(self, r):
         data = await r.config_get()
         rdbname = data['dbfilename']
@@ -99,18 +99,18 @@ class TestRedisCommands(object):
         finally:
             assert await r.config_set('dbfilename', rdbname)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_dbsize(self, r):
         await r.flushdb()
         await r.set('a', 'foo')
         await r.set('b', 'bar')
         assert await r.dbsize() == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_echo(self, r):
         assert await r.echo('foo bar') == b'foo bar'
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_info(self, r):
         await r.set('a', 'foo')
         await r.set('b', 'bar')
@@ -118,11 +118,11 @@ class TestRedisCommands(object):
         assert isinstance(info, dict)
         assert info['db0']['keys'] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lastsave(self, r):
         assert isinstance(await r.lastsave(), datetime.datetime)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_object(self, r):
         await r.set('a', 'foo')
         assert isinstance(await r.object('refcount', 'a'), int)
@@ -130,12 +130,12 @@ class TestRedisCommands(object):
         assert await r.object('encoding', 'a') in (b('raw'), b('embstr'))
         assert await r.object('idletime', 'invalid-key') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_ping(self, r):
         assert await r.ping()
 
-    async def slowlog(self):
-        client = aredis.StrictRedis()
+    async def slowlog(self, *, loop):
+        client = aredis.StrictRedis(loop=loop)
         current_config = await client.config_get()
         old_slower_than_value = current_config['slowlog-log-slower-than']
         old_max_length_value = current_config['slowlog-max-len']
@@ -143,14 +143,14 @@ class TestRedisCommands(object):
         await client.config_set('slowlog-max-len', 128)
         return old_slower_than_value, old_max_length_value
 
-    async def cleanup(self, old_slower_than_value, old_max_legnth_value):
-        client = aredis.StrictRedis()
+    async def cleanup(self, old_slower_than_value, old_max_legnth_value, *, loop):
+        client = aredis.StrictRedis(loop=loop)
         await client.config_set('slowlog-log-slower-than', old_slower_than_value)
         await client.config_set('slowlog-max-len', old_max_legnth_value)
 
-    @pytest.mark.asyncio
-    async def test_slowlog_get(self, r):
-        sl_v, length_v = await self.slowlog()
+    @pytest.mark.asyncio(forbid_global_loop=True)
+    async def test_slowlog_get(self, r, event_loop):
+        sl_v, length_v = await self.slowlog(loop=event_loop)
         await r.slowlog_reset()
         unicode_string = '3456abcd3421'
         await r.get(unicode_string)
@@ -170,11 +170,11 @@ class TestRedisCommands(object):
         # make sure other attributes are typed correctly
         assert isinstance(slowlog[0]['start_time'], int)
         assert isinstance(slowlog[0]['duration'], int)
-        await self.cleanup(sl_v, length_v)
+        await self.cleanup(sl_v, length_v, loop=event_loop)
 
-    @pytest.mark.asyncio
-    async def test_slowlog_get_limit(self, r):
-        sl_v, length_v = await self.slowlog()
+    @pytest.mark.asyncio(forbid_global_loop=True)
+    async def test_slowlog_get_limit(self, r, event_loop):
+        sl_v, length_v = await self.slowlog(loop=event_loop)
         assert await r.slowlog_reset()
         await r.get('foo')
         await r.get('bar')
@@ -183,17 +183,17 @@ class TestRedisCommands(object):
         commands = [log['command'] for log in slowlog]
         assert b('GET foo') not in commands
         assert b('GET bar') in commands
-        await self.cleanup(sl_v, length_v)
+        await self.cleanup(sl_v, length_v, loop=event_loop)
 
-    @pytest.mark.asyncio
-    async def test_slowlog_length(self, r):
-        sl_v, length_v = await self.slowlog()
+    @pytest.mark.asyncio(forbid_global_loop=True)
+    async def test_slowlog_length(self, r, event_loop):
+        sl_v, length_v = await self.slowlog(loop=event_loop)
         await r.get('foo')
         assert isinstance(await r.slowlog_len(), int)
-        await self.cleanup(sl_v, length_v)
+        await self.cleanup(sl_v, length_v, loop=event_loop)
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_time(self, r):
         t = await r.time()
         assert len(t) == 2
@@ -201,7 +201,7 @@ class TestRedisCommands(object):
         assert isinstance(t[1], int)
 
     # BASIC KEY COMMANDS
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_append(self, r):
         await r.flushdb()
         assert await r.append('a', 'a1') == 2
@@ -210,7 +210,7 @@ class TestRedisCommands(object):
         assert await r.get('a') == b('a1a2')
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitcount(self, r):
         await r.flushdb()
         await r.setbit('a', 5, True)
@@ -231,7 +231,7 @@ class TestRedisCommands(object):
         assert await r.bitcount('a', 1, 1) == 1
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitop_not_empty_string(self, r):
         await r.flushdb()
         await r.set('a', '')
@@ -239,7 +239,7 @@ class TestRedisCommands(object):
         assert await r.get('r') is None
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitop_not(self, r):
         test_str = b('\xAA\x00\xFF\x55')
         correct = ~0xAA00FF55 & 0xFFFFFFFF
@@ -248,7 +248,7 @@ class TestRedisCommands(object):
         assert int(binascii.hexlify(await r.get('r')), 16) == correct
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitop_not_in_place(self, r):
         test_str = b('\xAA\x00\xFF\x55')
         correct = ~0xAA00FF55 & 0xFFFFFFFF
@@ -257,7 +257,7 @@ class TestRedisCommands(object):
         assert int(binascii.hexlify(await r.get('a')), 16) == correct
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitop_single_string(self, r):
         test_str = b('\x01\x02\xFF')
         await r.set('a', test_str)
@@ -269,7 +269,7 @@ class TestRedisCommands(object):
         assert await r.get('res3') == test_str
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitop_string_operands(self, r):
         await r.set('a', b('\x01\x02\xFF\xFF'))
         await r.set('b', b('\x01\x02\xFF'))
@@ -281,7 +281,7 @@ class TestRedisCommands(object):
         assert int(binascii.hexlify(await r.get('res3')), 16) == 0x000000FF
 
     @skip_if_server_version_lt('2.8.7')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitpos(self, r):
         key = 'key:bitpos'
         await r.set(key, b('\xff\xf0\x00'))
@@ -295,7 +295,7 @@ class TestRedisCommands(object):
         assert await r.bitpos(key, 1) == -1
 
     @skip_if_server_version_lt('2.8.7')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitpos_wrong_arguments(self, r):
         key = 'key:bitpos:wrong:args'
         await r.set(key, b('\xff\xf0\x00'))
@@ -305,21 +305,21 @@ class TestRedisCommands(object):
             await r.bitpos(key, 7) == 12
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitfield_set(self, r):
         key = 'key:bitfield:set'
         assert [0] == await r.bitfield(key).set('i4', '#1', 100).exc()
         assert [4] == await r.bitfield(key).set('i4', '4', 101).exc()
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitfield_set(self, r):
         key = 'key:bitfield:get'
         await r.set(key, '\x00d')
         assert [100] == await r.bitfield(key).get('i8', '#1').exc()
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitfield_incrby(self, r):
         key = 'key:bitfield:incrby'
         await r.bitfield(key).incrby('u2', 10, 1).exc()
@@ -329,7 +329,7 @@ class TestRedisCommands(object):
         assert [-128] == await r.bitfield(key).incrby('i8', 0, 128).exc()
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_bitfield_overflow(self, r):
         key = 'key:bitfield:overflow'
         # nothing too happen
@@ -340,7 +340,7 @@ class TestRedisCommands(object):
         await r.delete(key)
         assert [None] == await r.bitfield(key).overflow('fail').incrby('i8', 0, 128).exc()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_decr(self, r):
         await r.flushdb()
         assert await r.decr('a') == -1
@@ -350,14 +350,14 @@ class TestRedisCommands(object):
         assert await r.decr('a', amount=5) == -7
         assert await r.get('a') == b('-7')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_delete(self, r):
         await r.flushdb()
         assert await r.delete('a') == 0
         await r.set('a', 'foo')
         assert await r.delete('a') == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_delete_with_multiple_keys(self, r):
         await r.set('a', 'foo')
         await r.set('b', 'bar')
@@ -366,7 +366,7 @@ class TestRedisCommands(object):
         assert await r.get('b') is None
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_dump_and_restore(self, r):
         await r.flushdb()
         await r.set('a', 'foo')
@@ -376,7 +376,7 @@ class TestRedisCommands(object):
         assert await r.get('a') == b('foo')
 
     @skip_if_server_version_lt('3.0.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_dump_and_restore_and_replace(self, r):
         await r.flushdb()
         await r.set('a', 'bar')
@@ -387,14 +387,14 @@ class TestRedisCommands(object):
         await r.restore('a', 0, dumped, replace=True)
         assert await r.get('a') == b('bar')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_exists(self, r):
         await r.flushdb()
         assert not await r.exists('a')
         await r.set('a', 'foo')
         assert await r.exists('a')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_expire(self, r):
         await r.flushdb()
         assert not await r.expire('a', 10)
@@ -404,7 +404,7 @@ class TestRedisCommands(object):
         assert await r.persist('a')
         assert await r.ttl('a') == -1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_expireat_datetime(self, r):
         await r.flushdb()
         expire_at = await redis_server_time(r) + datetime.timedelta(minutes=1)
@@ -412,13 +412,13 @@ class TestRedisCommands(object):
         assert await r.expireat('a', expire_at)
         assert 0 < await r.ttl('a') <= 61
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_expireat_no_key(self, r):
         await r.flushdb()
         expire_at = await redis_server_time(r) + datetime.timedelta(minutes=1)
         assert not await r.expireat('a', expire_at)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_expireat_unixtime(self, r):
         await r.flushdb()
         expire_at = await redis_server_time(r) + datetime.timedelta(minutes=1)
@@ -427,7 +427,7 @@ class TestRedisCommands(object):
         assert await r.expireat('a', expire_at_seconds)
         assert 0 < await r.ttl('a') <= 61
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_get_and_set(self, r):
         await r.flushdb()
         # get and set can't be tested independently of each other
@@ -442,7 +442,7 @@ class TestRedisCommands(object):
         assert await r.get('integer') == b(str(integer))
         assert (await r.get('unicode_string')).decode('utf-8') == unicode_string
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_get_set_bit(self, r):
         await r.flushdb()
         # no value
@@ -460,7 +460,7 @@ class TestRedisCommands(object):
         assert await r.setbit('a', 5, True)
         assert await r.getbit('a', 5)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_getrange(self, r):
         await r.flushdb()
         await r.set('a', 'foo')
@@ -468,14 +468,14 @@ class TestRedisCommands(object):
         assert await r.getrange('a', 0, 2) == b('foo')
         assert await r.getrange('a', 3, 4) == b('')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_getset(self, r):
         await r.flushdb()
         assert await r.getset('a', 'foo') is None
         assert await r.getset('a', 'bar') == b('foo')
         assert await r.get('a') == b('bar')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_incr(self, r):
         await r.flushdb()
         assert await r.incr('a') == 1
@@ -485,7 +485,7 @@ class TestRedisCommands(object):
         assert await r.incr('a', amount=5) == 7
         assert await r.get('a') == b('7')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_incrby(self, r):
         await r.flushdb()
         assert await r.incrby('a') == 1
@@ -493,7 +493,7 @@ class TestRedisCommands(object):
         assert await r.get('a') == b('5')
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_incrbyfloat(self, r):
         await r.flushdb()
         assert await r.incrbyfloat('a') == 1.0
@@ -501,7 +501,7 @@ class TestRedisCommands(object):
         assert await r.incrbyfloat('a', 1.1) == 2.1
         assert float(await r.get('a')) == float(2.1)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_keys(self, r):
         await r.flushdb()
         assert await r.keys() == []
@@ -512,7 +512,7 @@ class TestRedisCommands(object):
         assert set(await r.keys(pattern='test_*')) == keys_with_underscores
         assert set(await r.keys(pattern='test*')) == keys
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_mget(self, r):
         await r.flushdb()
         assert await r.mget(['a', 'b']) == [None, None]
@@ -521,21 +521,21 @@ class TestRedisCommands(object):
         await r.set('c', '3')
         assert await r.mget('a', 'other', 'b', 'c') == [b('1'), None, b('2'), b('3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_mset(self, r):
         d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
         assert await r.mset(d)
         for k, v in iteritems(d):
             assert await r.get(k) == v
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_mset_kwargs(self, r):
         d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
         assert await r.mset(**d)
         for k, v in iteritems(d):
             assert await r.get(k) == v
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_msetnx(self, r):
         await r.flushdb()
         d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
@@ -546,7 +546,7 @@ class TestRedisCommands(object):
             assert await r.get(k) == v
         assert await r.get('d') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_msetnx_kwargs(self, r):
         await r.flushdb()
         d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
@@ -558,7 +558,7 @@ class TestRedisCommands(object):
         assert await r.get('d') is None
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pexpire(self, r):
         await r.flushdb()
         assert not await r.pexpire('a', 60000)
@@ -569,7 +569,7 @@ class TestRedisCommands(object):
         assert await r.pttl('a') < 0
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pexpireat_datetime(self, r):
         expire_at = await redis_server_time(r) + datetime.timedelta(minutes=1)
         await r.set('a', 'foo')
@@ -577,14 +577,14 @@ class TestRedisCommands(object):
         assert 0 < await r.pttl('a') <= 61000
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pexpireat_no_key(self, r):
         await r.flushdb()
         expire_at = await redis_server_time(r) + datetime.timedelta(minutes=1)
         assert not await r.pexpireat('a', expire_at)
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pexpireat_unixtime(self, r):
         await r.flushdb()
         expire_at = await redis_server_time(r) + datetime.timedelta(minutes=1)
@@ -594,7 +594,7 @@ class TestRedisCommands(object):
         assert 0 < await r.pttl('a') <= 61000
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_psetex(self, r):
         await r.flushdb()
         assert await r.psetex('a', 1000, 'value')
@@ -602,7 +602,7 @@ class TestRedisCommands(object):
         assert 0 < await r.pttl('a') <= 1000
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_psetex_timedelta(self, r):
         await r.flushdb()
         expire_at = datetime.timedelta(milliseconds=1000)
@@ -610,7 +610,7 @@ class TestRedisCommands(object):
         assert await r.get('a') == b('value')
         assert 0 < await r.pttl('a') <= 1000
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_randomkey(self, r):
         await r.flushdb()
         assert await r.randomkey() is None
@@ -618,7 +618,7 @@ class TestRedisCommands(object):
             await r.set(key, 1)
         assert await r.randomkey() in (b('a'), b('b'), b('c'))
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_rename(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -626,7 +626,7 @@ class TestRedisCommands(object):
         assert await r.get('a') is None
         assert await r.get('b') == b('1')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_renamenx(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -636,7 +636,7 @@ class TestRedisCommands(object):
         assert await r.get('b') == b('2')
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_set_nx(self, r):
         await r.flushdb()
         assert await r.set('a', '1', nx=True)
@@ -644,7 +644,7 @@ class TestRedisCommands(object):
         assert await r.get('a') == b('1')
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_set_xx(self, r):
         await r.flushdb()
         assert not await r.set('a', '1', xx=True)
@@ -654,7 +654,7 @@ class TestRedisCommands(object):
         assert await r.get('a') == b('2')
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_set_px(self, r):
         await r.flushdb()
         assert await r.set('a', '1', px=10000)
@@ -663,7 +663,7 @@ class TestRedisCommands(object):
         assert 0 < await r.ttl('a') <= 10
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_set_px_timedelta(self, r):
         await r.flushdb()
         expire_at = datetime.timedelta(milliseconds=1000)
@@ -672,14 +672,14 @@ class TestRedisCommands(object):
         assert 0 < await r.ttl('a') <= 1
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_set_ex(self, r):
         await r.flushdb()
         assert await r.set('a', '1', ex=10)
         assert 0 < await r.ttl('a') <= 10
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_set_ex_timedelta(self, r):
         await r.flushdb()
         expire_at = datetime.timedelta(seconds=60)
@@ -687,21 +687,21 @@ class TestRedisCommands(object):
         assert 0 < await r.ttl('a') <= 60
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_set_multipleoptions(self, r):
         await r.flushdb()
         await r.set('a', 'val')
         assert await r.set('a', '1', xx=True, px=10000)
         assert 0 < await r.ttl('a') <= 10
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_setex(self, r):
         await r.flushdb()
         assert await r.setex('a', 60, '1')
         assert await r.get('a') == b('1')
         assert 0 < await r.ttl('a') <= 60
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_setnx(self, r):
         await r.flushdb()
         assert await r.setnx('a', '1')
@@ -709,7 +709,7 @@ class TestRedisCommands(object):
         assert not await r.setnx('a', '2')
         assert await r.get('a') == b('1')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_setrange(self, r):
         await r.flushdb()
         assert await r.setrange('a', 5, 'foo') == 8
@@ -718,13 +718,13 @@ class TestRedisCommands(object):
         assert await r.setrange('a', 6, '12345') == 11
         assert await r.get('a') == b('abcdef12345')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_strlen(self, r):
         await r.flushdb()
         await r.set('a', 'foo')
         assert await r.strlen('a') == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_substr(self, r):
         await r.flushdb()
         await r.set('a', '0123456789')
@@ -733,7 +733,7 @@ class TestRedisCommands(object):
         assert await r.substr('a', 3, 5) == b('345')
         assert await r.substr('a', 3, -2) == b('345678')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_type(self, r):
         await r.flushdb()
         assert await r.type('a') == b('none')
@@ -750,7 +750,7 @@ class TestRedisCommands(object):
         assert await r.type('a') == b('zset')
 
     @skip_if_server_version_lt('3.2.1')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_touch(self, r):
         await r.flushdb()
         keys = ['a', 'b', 'c', 'd']
@@ -759,7 +759,7 @@ class TestRedisCommands(object):
         assert await r.touch(keys) == len(keys)
 
     @skip_if_server_version_lt('4.0.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_unlink(self, r):
         await r.flushdb()
         keys = ['a', 'b', 'c', 'd']
@@ -770,7 +770,7 @@ class TestRedisCommands(object):
             assert r.get(key) is None
 
     # LIST COMMANDS
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_blpop(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2')
@@ -783,7 +783,7 @@ class TestRedisCommands(object):
         await r.rpush('c', '1')
         assert await r.blpop('c', timeout=1) == (b('c'), b('1'))
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_brpop(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2')
@@ -796,7 +796,7 @@ class TestRedisCommands(object):
         await r.rpush('c', '1')
         assert await r.brpop('c', timeout=1) == (b('c'), b('1'))
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_brpoplpush(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2')
@@ -807,13 +807,13 @@ class TestRedisCommands(object):
         assert await r.lrange('a', 0, -1) == []
         assert await r.lrange('b', 0, -1) == [b('1'), b('2'), b('3'), b('4')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_brpoplpush_empty_string(self, r):
         await r.flushdb()
         await r.rpush('a', '')
         assert await r.brpoplpush('a', 'b') == b('')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lindex(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2', '3')
@@ -821,7 +821,7 @@ class TestRedisCommands(object):
         assert await r.lindex('a', '1') == b('2')
         assert await r.lindex('a', '2') == b('3')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_linsert(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2', '3')
@@ -831,13 +831,13 @@ class TestRedisCommands(object):
         assert await r.lrange('a', 0, -1) == \
             [b('1'), b('1.5'), b('2'), b('2.5'), b('3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_llen(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2', '3')
         assert await r.llen('a') == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lpop(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2', '3')
@@ -846,7 +846,7 @@ class TestRedisCommands(object):
         assert await r.lpop('a') == b('3')
         assert await r.lpop('a') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lpush(self, r):
         await r.flushdb()
         assert await r.lpush('a', '1') == 1
@@ -854,7 +854,7 @@ class TestRedisCommands(object):
         assert await r.lpush('a', '3', '4') == 4
         assert await r.lrange('a', 0, -1) == [b('4'), b('3'), b('2'), b('1')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lpushx(self, r):
         await r.flushdb()
         assert await r.lpushx('a', '1') == 0
@@ -863,7 +863,7 @@ class TestRedisCommands(object):
         assert await r.lpushx('a', '4') == 4
         assert await r.lrange('a', 0, -1) == [b('4'), b('1'), b('2'), b('3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lrange(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2', '3', '4', '5')
@@ -871,7 +871,7 @@ class TestRedisCommands(object):
         assert await r.lrange('a', 2, 10) == [b('3'), b('4'), b('5')]
         assert await r.lrange('a', 0, -1) == [b('1'), b('2'), b('3'), b('4'), b('5')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lrem(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '1', '1', '1')
@@ -880,7 +880,7 @@ class TestRedisCommands(object):
         assert await r.lrem('a', 3, '1') == 3
         assert await r.lrange('a', 0, -1) == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lset(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2', '3')
@@ -888,14 +888,14 @@ class TestRedisCommands(object):
         assert await r.lset('a', 1, '4')
         assert await r.lrange('a', 0, 2) == [b('1'), b('4'), b('3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_ltrim(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2', '3')
         assert await r.ltrim('a', 0, 1)
         assert await r.lrange('a', 0, -1) == [b('1'), b('2')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_rpop(self, r):
         await r.flushdb()
         await r.rpush('a', '1', '2', '3')
@@ -904,7 +904,7 @@ class TestRedisCommands(object):
         assert await r.rpop('a') == b('1')
         assert await r.rpop('a') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_rpoplpush(self, r):
         await r.flushdb()
         await r.rpush('a', 'a1', 'a2', 'a3')
@@ -913,7 +913,7 @@ class TestRedisCommands(object):
         assert await r.lrange('a', 0, -1) == [b('a1'), b('a2')]
         assert await r.lrange('b', 0, -1) == [b('a3'), b('b1'), b('b2'), b('b3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_rpush(self, r):
         await r.flushdb()
         assert await r.rpush('a', '1') == 1
@@ -921,7 +921,7 @@ class TestRedisCommands(object):
         assert await r.rpush('a', '3', '4') == 4
         assert await r.lrange('a', 0, -1) == [b('1'), b('2'), b('3'), b('4')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_rpushx(self, r):
         await r.flushdb()
         assert await r.rpushx('a', 'b') == 0
@@ -932,7 +932,7 @@ class TestRedisCommands(object):
 
     # SCAN COMMANDS
     @skip_if_server_version_lt('2.8.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_scan(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -946,7 +946,7 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.8.0')
     @skip_python_vsersion_lt('3.6')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_scan_iter(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -960,7 +960,7 @@ class TestRedisCommands(object):
             assert key == b('a')
 
     @skip_if_server_version_lt('2.8.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sscan(self, r):
         await r.flushdb()
         await r.sadd('a', 1, 2, 3)
@@ -972,7 +972,7 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.8.0')
     @skip_python_vsersion_lt('3.6')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sscan_iter(self, r):
         await r.flushdb()
         await r.sadd('a', 1, 2, 3)
@@ -984,7 +984,7 @@ class TestRedisCommands(object):
             assert member == b('1')
 
     @skip_if_server_version_lt('2.8.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hscan(self, r):
         await r.flushdb()
         await r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
@@ -996,7 +996,7 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.8.0')
     @skip_python_vsersion_lt('3.6')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hscan_iter(self, r):
         await r.flushdb()
         await r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
@@ -1008,7 +1008,7 @@ class TestRedisCommands(object):
             assert dict([data]) == {b('a'): b('1')}
 
     @skip_if_server_version_lt('2.8.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zscan(self, r):
         await r.flushdb()
         await r.zadd('a', 1, 'a', 2, 'b', 3, 'c')
@@ -1020,7 +1020,7 @@ class TestRedisCommands(object):
 
     @skip_if_server_version_lt('2.8.0')
     @skip_python_vsersion_lt('3.6')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zscan_iter(self, r):
         await r.zadd('a', 1, 'a', 2, 'b', 3, 'c')
         pairs = set()
@@ -1031,20 +1031,20 @@ class TestRedisCommands(object):
             assert pair == (b('a'), 1)
 
     # SET COMMANDS
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sadd(self, r):
         await r.flushdb()
         members = set([b('1'), b('2'), b('3')])
         await r.sadd('a', *members)
         assert await r.smembers('a') == members
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_scard(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2', '3')
         assert await r.scard('a') == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sdiff(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2', '3')
@@ -1052,7 +1052,7 @@ class TestRedisCommands(object):
         await r.sadd('b', '2', '3')
         assert await r.sdiff('a', 'b') == set([b('1')])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sdiffstore(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2', '3')
@@ -1062,7 +1062,7 @@ class TestRedisCommands(object):
         assert await r.sdiffstore('c', 'a', 'b') == 1
         assert await r.smembers('c') == set([b('1')])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sinter(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2', '3')
@@ -1070,7 +1070,7 @@ class TestRedisCommands(object):
         await r.sadd('b', '2', '3')
         assert await r.sinter('a', 'b') == set([b('2'), b('3')])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sinterstore(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2', '3')
@@ -1080,7 +1080,7 @@ class TestRedisCommands(object):
         assert await r.sinterstore('c', 'a', 'b') == 2
         assert await r.smembers('c') == set([b('2'), b('3')])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sismember(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2', '3')
@@ -1089,13 +1089,13 @@ class TestRedisCommands(object):
         assert await r.sismember('a', '3')
         assert not await r.sismember('a', '4')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_smembers(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2', '3')
         assert await r.smembers('a') == set([b('1'), b('2'), b('3')])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_smove(self, r):
         await r.flushdb()
         await r.sadd('a', 'a1', 'a2')
@@ -1104,7 +1104,7 @@ class TestRedisCommands(object):
         assert await r.smembers('a') == set([b('a2')])
         assert await r.smembers('b') == set([b('b1'), b('b2'), b('a1')])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_spop(self, r):
         await r.flushdb()
         s = [b('1'), b('2'), b('3')]
@@ -1113,7 +1113,7 @@ class TestRedisCommands(object):
         assert value in s
         assert await r.smembers('a') == set(s) - set([value])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_srandmember(self, r):
         await r.flushdb()
         s = [b('1'), b('2'), b('3')]
@@ -1121,7 +1121,7 @@ class TestRedisCommands(object):
         assert await r.srandmember('a') in s
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_srandmember_multi_value(self, r):
         await r.flushdb()
         s = [b('1'), b('2'), b('3')]
@@ -1130,7 +1130,7 @@ class TestRedisCommands(object):
         assert len(randoms) == 2
         assert set(randoms).intersection(s) == set(randoms)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_srem(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2', '3', '4')
@@ -1138,14 +1138,14 @@ class TestRedisCommands(object):
         assert await r.srem('a', '2', '4') == 2
         assert await r.smembers('a') == set([b('1'), b('3')])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sunion(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2')
         await r.sadd('b', '2', '3')
         assert await r.sunion('a', 'b') == set([b('1'), b('2'), b('3')])
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sunionstore(self, r):
         await r.flushdb()
         await r.sadd('a', '1', '2')
@@ -1154,19 +1154,19 @@ class TestRedisCommands(object):
         assert await r.smembers('c') == set([b('1'), b('2'), b('3')])
 
     # SORTED SET COMMANDS
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zadd(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
         assert await r.zrange('a', 0, -1) == [b('a1'), b('a2'), b('a3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zcard(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
         assert await r.zcard('a') == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zcount(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1174,7 +1174,7 @@ class TestRedisCommands(object):
         assert await r.zcount('a', 1, 2) == 2
         assert await r.zcount('a', 10, 20) == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zincrby(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1184,14 +1184,14 @@ class TestRedisCommands(object):
         assert await r.zscore('a', 'a3') == 8.0
 
     @skip_if_server_version_lt('2.8.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zlexcount(self, r):
         await r.flushdb()
         await r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
         assert await r.zlexcount('a', '-', '+') == 7
         assert await r.zlexcount('a', '[b', '[f') == 5
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zinterstore_sum(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=1, a3=1)
@@ -1201,7 +1201,7 @@ class TestRedisCommands(object):
         assert await r.zrange('d', 0, -1, withscores=True) == \
             [(b('a3'), 8), (b('a1'), 9)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zinterstore_max(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=1, a3=1)
@@ -1211,7 +1211,7 @@ class TestRedisCommands(object):
         assert await r.zrange('d', 0, -1, withscores=True) == \
             [(b('a3'), 5), (b('a1'), 6)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zinterstore_min(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1221,7 +1221,7 @@ class TestRedisCommands(object):
         assert await r.zrange('d', 0, -1, withscores=True) == \
             [(b('a1'), 1), (b('a3'), 3)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zinterstore_with_weight(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=1, a3=1)
@@ -1231,7 +1231,7 @@ class TestRedisCommands(object):
         assert await r.zrange('d', 0, -1, withscores=True) == \
             [(b('a3'), 20), (b('a1'), 23)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrange(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1249,7 +1249,7 @@ class TestRedisCommands(object):
             [(b('a1'), 1), (b('a2'), 2)]
 
     @skip_if_server_version_lt('2.8.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrangebylex(self, r):
         await r.flushdb()
         await r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
@@ -1261,7 +1261,7 @@ class TestRedisCommands(object):
         assert await r.zrangebylex('a', '-', '+', start=3, num=2) == [b('d'), b('e')]
 
     @skip_if_server_version_lt('2.9.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrevrangebylex(self, r):
         await r.flushdb()
         await r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
@@ -1273,7 +1273,7 @@ class TestRedisCommands(object):
         assert await r.zrevrangebylex('a', '+', '-', start=3, num=2) == \
             [b('d'), b('c')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrangebyscore(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -1292,7 +1292,7 @@ class TestRedisCommands(object):
                                score_cast_func=int) == \
             [(b('a2'), 2), (b('a3'), 3), (b('a4'), 4)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrank(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -1300,7 +1300,7 @@ class TestRedisCommands(object):
         assert await r.zrank('a', 'a2') == 1
         assert await r.zrank('a', 'a6') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrem(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1309,7 +1309,7 @@ class TestRedisCommands(object):
         assert await r.zrem('a', 'b') == 0
         assert await r.zrange('a', 0, -1) == [b('a1'), b('a3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrem_multiple_keys(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1317,7 +1317,7 @@ class TestRedisCommands(object):
         assert await r.zrange('a', 0, 5) == [b('a3')]
 
     @skip_if_server_version_lt('2.8.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zremrangebylex(self, r):
         await r.flushdb()
         await r.zadd('a', a=0, b=0, c=0, d=0, e=0, f=0, g=0)
@@ -1328,14 +1328,14 @@ class TestRedisCommands(object):
         assert await r.zremrangebylex('a', '[h', '+') == 0
         assert await r.zrange('a', 0, -1) == [b('d'), b('e')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zremrangebyrank(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
         assert await r.zremrangebyrank('a', 1, 3) == 3
         assert await r.zrange('a', 0, 5) == [b('a1'), b('a5')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zremrangebyscore(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -1344,7 +1344,7 @@ class TestRedisCommands(object):
         assert await r.zremrangebyscore('a', 2, 4) == 0
         assert await r.zrange('a', 0, -1) == [b('a1'), b('a5')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrevrange(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1362,7 +1362,7 @@ class TestRedisCommands(object):
                            score_cast_func=int) == \
             [(b('a3'), 3.0), (b('a2'), 2.0)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrevrangebyscore(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -1381,7 +1381,7 @@ class TestRedisCommands(object):
                                   score_cast_func=int) == \
             [(b('a4'), 4), (b('a3'), 3), (b('a2'), 2)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zrevrank(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3, a4=4, a5=5)
@@ -1389,7 +1389,7 @@ class TestRedisCommands(object):
         assert await r.zrevrank('a', 'a2') == 3
         assert await r.zrevrank('a', 'a6') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zscore(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1397,7 +1397,7 @@ class TestRedisCommands(object):
         assert await r.zscore('a', 'a2') == 2.0
         assert await r.zscore('a', 'a4') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zunionstore_sum(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=1, a3=1)
@@ -1407,7 +1407,7 @@ class TestRedisCommands(object):
         assert await r.zrange('d', 0, -1, withscores=True) == \
             [(b('a2'), 3), (b('a4'), 4), (b('a3'), 8), (b('a1'), 9)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zunionstore_max(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=1, a3=1)
@@ -1417,7 +1417,7 @@ class TestRedisCommands(object):
         assert await r.zrange('d', 0, -1, withscores=True) == \
             [(b('a2'), 2), (b('a4'), 4), (b('a3'), 5), (b('a1'), 6)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zunionstore_min(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=2, a3=3)
@@ -1427,7 +1427,7 @@ class TestRedisCommands(object):
         assert await r.zrange('d', 0, -1, withscores=True) == \
             [(b('a1'), 1), (b('a2'), 2), (b('a3'), 3), (b('a4'), 4)]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_zunionstore_with_weight(self, r):
         await r.flushdb()
         await r.zadd('a', a1=1, a2=1, a3=1)
@@ -1439,7 +1439,7 @@ class TestRedisCommands(object):
 
     # HYPERLOGLOG TESTS
     @skip_if_server_version_lt('2.8.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pfadd(self, r):
         await r.flushdb()
         members = set([b('1'), b('2'), b('3')])
@@ -1448,7 +1448,7 @@ class TestRedisCommands(object):
         assert await r.pfcount('a') == len(members)
 
     @skip_if_server_version_lt('2.8.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pfcount(self, r):
         await r.flushdb()
         members = set([b('1'), b('2'), b('3')])
@@ -1460,7 +1460,7 @@ class TestRedisCommands(object):
         assert await r.pfcount('a', 'b') == len(members_b.union(members))
 
     @skip_if_server_version_lt('2.8.9')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pfmerge(self, r):
         await r.flushdb()
         mema = set([b('1'), b('2'), b('3')])
@@ -1475,7 +1475,7 @@ class TestRedisCommands(object):
         assert await r.pfcount('d') == 7
 
     # HASH COMMANDS
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hget_and_hset(self, r):
         await r.flushdb()
         await r.hmset('a', {'1': 1, '2': 2, '3': 3})
@@ -1494,7 +1494,7 @@ class TestRedisCommands(object):
         # key inside of hash that doesn't exist returns null value
         assert await r.hget('a', 'b') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hdel(self, r):
         await r.flushdb()
         await r.hmset('a', {'1': 1, '2': 2, '3': 3})
@@ -1503,21 +1503,21 @@ class TestRedisCommands(object):
         assert await r.hdel('a', '1', '3') == 2
         assert await r.hlen('a') == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hexists(self, r):
         await r.flushdb()
         await r.hmset('a', {'1': 1, '2': 2, '3': 3})
         assert await r.hexists('a', '1')
         assert not await r.hexists('a', '4')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hgetall(self, r):
         await r.flushdb()
         h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
         await r.hmset('a', h)
         assert await r.hgetall('a') == h
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hincrby(self, r):
         await r.flushdb()
         assert await r.hincrby('a', '1') == 1
@@ -1525,14 +1525,14 @@ class TestRedisCommands(object):
         assert await r.hincrby('a', '1', amount=-2) == 1
 
     @skip_if_server_version_lt('2.6.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hincrbyfloat(self, r):
         await r.flushdb()
         assert await r.hincrbyfloat('a', '1') == 1.0
         assert await r.hincrbyfloat('a', '1') == 2.0
         assert await r.hincrbyfloat('a', '1', 1.2) == 3.2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hkeys(self, r):
         await r.flushdb()
         h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
@@ -1541,26 +1541,26 @@ class TestRedisCommands(object):
         remote_keys = await r.hkeys('a')
         assert (sorted(local_keys) == sorted(remote_keys))
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hlen(self, r):
         await r.flushdb()
         await r.hmset('a', {'1': 1, '2': 2, '3': 3})
         assert await r.hlen('a') == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hmget(self, r):
         await r.flushdb()
         assert await r.hmset('a', {'a': 1, 'b': 2, 'c': 3})
         assert await r.hmget('a', 'a', 'b', 'c') == [b('1'), b('2'), b('3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hmset(self, r):
         await r.flushdb()
         h = {b('a'): b('1'), b('b'): b('2'), b('c'): b('3')}
         assert await r.hmset('a', h)
         assert await r.hgetall('a') == h
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hsetnx(self, r):
         await r.flushdb()
         # Initially set the hash field
@@ -1569,7 +1569,7 @@ class TestRedisCommands(object):
         assert not await r.hsetnx('a', '1', 2)
         assert await r.hget('a', '1') == b('1')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hvals(self, r):
         await r.flushdb()
         h = {b('a1'): b('1'), b('a2'): b('2'), b('a3'): b('3')}
@@ -1579,7 +1579,7 @@ class TestRedisCommands(object):
         assert sorted(local_vals) == sorted(remote_vals)
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_hstrlen(self, r):
         await r.flushdb()
         key = 'myhash'
@@ -1592,19 +1592,19 @@ class TestRedisCommands(object):
         assert await r.hstrlen(key, 'f3') == 4
 
     # SORT
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_basic(self, r):
         await r.flushdb()
         await r.rpush('a', '3', '2', '1', '4')
         assert await r.sort('a') == [b('1'), b('2'), b('3'), b('4')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_limited(self, r):
         await r.flushdb()
         await r.rpush('a', '3', '2', '1', '4')
         assert await r.sort('a', start=1, num=2) == [b('2'), b('3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_by(self, r):
         await r.flushdb()
         await r.set('score:1', 8)
@@ -1613,7 +1613,7 @@ class TestRedisCommands(object):
         await r.rpush('a', '3', '2', '1')
         assert await r.sort('a', by='score:*') == [b('2'), b('3'), b('1')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_get(self, r):
         await r.flushdb()
         await r.set('user:1', 'u1')
@@ -1622,7 +1622,7 @@ class TestRedisCommands(object):
         await r.rpush('a', '2', '3', '1')
         assert await r.sort('a', get='user:*') == [b('u1'), b('u2'), b('u3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_get_multi(self, r):
         await r.flushdb()
         await r.set('user:1', 'u1')
@@ -1632,7 +1632,7 @@ class TestRedisCommands(object):
         assert await r.sort('a', get=('user:*', '#')) == \
             [b('u1'), b('1'), b('u2'), b('2'), b('u3'), b('3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_get_groups_two(self, r):
         await r.flushdb()
         await r.set('user:1', 'u1')
@@ -1642,7 +1642,7 @@ class TestRedisCommands(object):
         assert await r.sort('a', get=('user:*', '#'), groups=True) == \
             [(b('u1'), b('1')), (b('u2'), b('2')), (b('u3'), b('3'))]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_groups_string_get(self, r):
         await r.flushdb()
         await r.set('user:1', 'u1')
@@ -1652,7 +1652,7 @@ class TestRedisCommands(object):
         with pytest.raises(DataError):
             await r.sort('a', get='user:*', groups=True)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_groups_just_one_get(self, r):
         await r.flushdb()
         await r.set('user:1', 'u1')
@@ -1662,7 +1662,7 @@ class TestRedisCommands(object):
         with pytest.raises(DataError):
             await r.sort('a', get=['user:*'], groups=True)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_groups_no_get(self, r):
         await r.flushdb()
         await r.set('user:1', 'u1')
@@ -1672,7 +1672,7 @@ class TestRedisCommands(object):
         with pytest.raises(DataError):
             await r.sort('a', groups=True)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_groups_three_gets(self, r):
         await r.flushdb()
         await r.set('user:1', 'u1')
@@ -1689,27 +1689,27 @@ class TestRedisCommands(object):
                 (b('u3'), b('d3'), b('3'))
         ]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_desc(self, r):
         await r.flushdb()
         await r.rpush('a', '2', '3', '1')
         assert await r.sort('a', desc=True) == [b('3'), b('2'), b('1')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_alpha(self, r):
         await r.flushdb()
         await r.rpush('a', 'e', 'c', 'b', 'd', 'a')
         assert await r.sort('a', alpha=True) == \
             [b('a'), b('b'), b('c'), b('d'), b('e')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_store(self, r):
         await r.flushdb()
         await r.rpush('a', '2', '3', '1')
         assert await r.sort('a', store='sorted_values') == 3
         assert await r.lrange('sorted_values', 0, -1) == [b('1'), b('2'), b('3')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_sort_all_options(self, r):
         await r.flushdb()
         await r.set('user:1:username', 'zeus')
@@ -1738,74 +1738,74 @@ class TestRedisCommands(object):
         assert await r.lrange('sorted', 0, 10) == \
             [b('vodka'), b('milk'), b('gin'), b('apple juice')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_addslots(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('ADDSLOTS', 1) is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_count_failure_reports(self, mock_cluster_resp_int):
         assert isinstance(await mock_cluster_resp_int.cluster(
             'COUNT-FAILURE-REPORTS', 'node'), int)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_countkeysinslot(self, mock_cluster_resp_int):
         assert isinstance(await mock_cluster_resp_int.cluster(
             'COUNTKEYSINSLOT', 2), int)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_delslots(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('DELSLOTS', 1) is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_failover(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('FAILOVER', 1) is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_forget(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('FORGET', 1) is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_info(self, mock_cluster_resp_info):
         assert isinstance(await mock_cluster_resp_info.cluster('info'), dict)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_keyslot(self, mock_cluster_resp_int):
         assert isinstance(await mock_cluster_resp_int.cluster(
             'keyslot', 'asdf'), int)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_meet(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('meet', 'ip', 'port', 1) is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_nodes(self, mock_cluster_resp_nodes):
         assert isinstance(await mock_cluster_resp_nodes.cluster('nodes'), dict)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_replicate(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('replicate', 'nodeid') is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_reset(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('reset', 'hard') is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_saveconfig(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('saveconfig') is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_setslot(self, mock_cluster_resp_ok):
         assert await mock_cluster_resp_ok.cluster('setslot', 1,
                                                   'IMPORTING', 'nodeid') is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cluster_slaves(self, mock_cluster_resp_slaves):
         assert isinstance(await mock_cluster_resp_slaves.cluster(
             'slaves', 'nodeid'), dict)
 
     # GEO COMMANDS
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_geoadd(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1815,14 +1815,14 @@ class TestRedisCommands(object):
         assert await r.zcard('barcelona') == 2
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_geoadd_invalid_params(self, r):
         await r.flushdb()
         with pytest.raises(RedisError):
             await r.geoadd('barcelona', *(1, 2))
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_geodist(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1832,7 +1832,7 @@ class TestRedisCommands(object):
         assert await r.geodist('barcelona', 'place1', 'place2') == 3067.4157
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_geodist_units(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1842,14 +1842,14 @@ class TestRedisCommands(object):
         assert await r.geodist('barcelona', 'place1', 'place2', 'km') == 3.0674
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_geodist_invalid_units(self, r):
         await r.flushdb()
         with pytest.raises(RedisError):
             assert await r.geodist('x', 'y', 'z', 'inches')
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_geohash(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1860,7 +1860,7 @@ class TestRedisCommands(object):
             [b'sp3e9yg3kd0', b'sp3e9cbc3t0']
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_geopos(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1873,7 +1873,7 @@ class TestRedisCommands(object):
              (2.18737632036209106, 41.40634178640635099)]
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadius(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1883,7 +1883,7 @@ class TestRedisCommands(object):
         assert await r.georadius('barcelona', 2.191, 41.433, 1000) == ['place1']
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadius_no_values(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1893,7 +1893,7 @@ class TestRedisCommands(object):
         assert await r.georadius('barcelona', 1, 2, 1000) == []
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadius_units(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1904,7 +1904,7 @@ class TestRedisCommands(object):
             ['place1']
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadius_with(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1934,7 +1934,7 @@ class TestRedisCommands(object):
                            withdist=True, withcoord=True, withhash=True) == []
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadius_count(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1945,7 +1945,7 @@ class TestRedisCommands(object):
             ['place1']
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadius_sort(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1958,7 +1958,7 @@ class TestRedisCommands(object):
             ['place2', 'place1']
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadius_store(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1969,7 +1969,7 @@ class TestRedisCommands(object):
         assert await r.zrange('places_barcelona', 0, -1) == [b'place1']
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadius_store_dist(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -1982,7 +1982,7 @@ class TestRedisCommands(object):
         assert await r.zscore('places_barcelona', 'place1') == 88.05060698409301
 
     @skip_if_server_version_lt('3.2.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_georadiusmember(self, r):
         await r.flushdb()
         values = (2.1909389952632, 41.433791470673, 'place1') +\
@@ -2004,7 +2004,7 @@ class TestRedisCommands(object):
 
 class TestBinarySave(object):
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_binary_get_set(self, r):
         await r.flushdb()
         assert await r.set(' foo bar ', '123')
@@ -2023,7 +2023,7 @@ class TestBinarySave(object):
         assert await r.delete(' foo\r\nbar\r\n ')
         assert await r.delete(' \r\n\t\x07\x13 ')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_binary_lists(self, r):
         await r.flushdb()
         mapping = {
@@ -2042,7 +2042,7 @@ class TestBinarySave(object):
         for key, value in iteritems(mapping):
             assert await r.lrange(key, 0, -1) == value
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_22_info(self, r):
         """
         Older Redis versions contained 'allocation_stats' in INFO that
@@ -2078,7 +2078,7 @@ class TestBinarySave(object):
         assert '6' in parsed['allocation_stats']
         assert '>=256' in parsed['allocation_stats']
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_large_responses(self, r):
         "The PythonParser has some special cases for return values > 1MB"
         # load up 5MB of data into a key
@@ -2087,7 +2087,7 @@ class TestBinarySave(object):
         await r.set('a', data)
         assert await r.get('a') == b(data)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_floating_point_encoding(self, r):
         """
         High precision floating point values sent to the server should keep

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,9 +6,9 @@ from aredis import (Connection,
                     UnixDomainSocketConnection)
 
 
-@pytest.mark.asyncio
-async def test_connect_tcp():
-    conn = Connection()
+@pytest.mark.asyncio(forbid_global_loop=True)
+async def test_connect_tcp(event_loop):
+    conn = Connection(loop=event_loop)
     assert conn.host == '127.0.0.1'
     assert conn.port == 6379
     assert str(conn) == 'Connection<host=127.0.0.1,port=6379,db=0>'
@@ -21,13 +21,13 @@ async def test_connect_tcp():
 
 
 # only test during dev
-# @pytest.mark.asyncio
-# async def test_connect_unix_socket():
+# @pytest.mark.asyncio(forbid_global_loop=True)
+# async def test_connect_unix_socket(event_loop):
 #     # to run this test case you should change your redis configuration
 #     # unixsocket /var/run/redis/redis.sock
 #     # unixsocketperm 777
 #     path = '/var/run/redis/redis.sock'
-#     conn = UnixDomainSocketConnection(path)
+#     conn = UnixDomainSocketConnection(path, event_loop)
 #     await conn.connect()
 #     assert conn.path == path
 #     assert str(conn) == 'UnixDomainSocketConnection<path={},db=0>'.format(path)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -13,7 +13,7 @@ class TestLock(object):
         kwargs['lock_class'] = self.lock_class
         return redis.lock(*args, **kwargs)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lock(self, r):
         await r.flushdb()
         lock = self.get_lock(r, 'foo')
@@ -23,7 +23,7 @@ class TestLock(object):
         await lock.release()
         assert await r.get('foo') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_competing_locks(self, r):
         lock1 = self.get_lock(r, 'foo')
         lock2 = self.get_lock(r, 'foo')
@@ -34,21 +34,21 @@ class TestLock(object):
         assert not await lock1.acquire(blocking=False)
         await lock2.release()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_timeout(self, r):
         lock = self.get_lock(r, 'foo', timeout=10)
         assert await lock.acquire(blocking=False)
         assert 8 < await r.ttl('foo') <= 10
         await lock.release()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_float_timeout(self, r):
         lock = self.get_lock(r, 'foo', timeout=9.5)
         assert await lock.acquire(blocking=False)
         assert 8 < await r.pttl('foo') <= 9500
         await lock.release()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_blocking_timeout(self, r):
         lock1 = self.get_lock(r, 'foo')
         assert await lock1.acquire(blocking=False)
@@ -58,7 +58,7 @@ class TestLock(object):
         assert (time.time() - start) > 0.2
         await lock1.release()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_context_manager(self, r):
         # blocking_timeout prevents a deadlock if the lock can't be acquired
         # for some reason
@@ -66,19 +66,19 @@ class TestLock(object):
             assert await r.get('foo') == lock.local.token
         assert await r.get('foo') is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_high_sleep_raises_error(self, r):
         "If sleep is higher than timeout, it should raise an error"
         with pytest.raises(LockError):
             self.get_lock(r, 'foo', timeout=1, sleep=2)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_releasing_unlocked_lock_raises_error(self, r):
         lock = self.get_lock(r, 'foo')
         with pytest.raises(LockError):
             await lock.release()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_releasing_lock_no_longer_owned_raises_error(self, r):
         lock = self.get_lock(r, 'foo')
         await lock.acquire(blocking=False)
@@ -89,7 +89,7 @@ class TestLock(object):
         # even though we errored, the token is still cleared
         assert lock.local.token is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_extend_lock(self, r):
         await r.flushdb()
         lock = self.get_lock(r, 'foo', timeout=10)
@@ -99,7 +99,7 @@ class TestLock(object):
         assert 16000 < await r.pttl('foo') <= 20000
         await lock.release()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_extend_lock_float(self, r):
         await r.flushdb()
         lock = self.get_lock(r, 'foo', timeout=10.0)
@@ -109,13 +109,13 @@ class TestLock(object):
         assert 16000 < await r.pttl('foo') <= 20000
         await lock.release()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_extending_unlocked_lock_raises_error(self, r):
         lock = self.get_lock(r, 'foo', timeout=10)
         with pytest.raises(LockError):
             await lock.extend(10)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_extending_lock_with_no_timeout_raises_error(self, r):
         lock = self.get_lock(r, 'foo')
         await r.flushdb()
@@ -124,7 +124,7 @@ class TestLock(object):
             await lock.extend(10)
         await lock.release()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_extending_lock_no_longer_owned_raises_error(self, r):
         lock = self.get_lock(r, 'foo')
         await r.flushdb()
@@ -140,14 +140,14 @@ class TestLuaLock(TestLock):
 
 class TestLockClassSelection(object):
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lock_class_argument(self, r):
         lock = r.lock('foo', lock_class=Lock)
         assert type(lock) == Lock
         lock = r.lock('foo', lock_class=LuaLock)
         assert type(lock) == LuaLock
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cached_lualock_flag(self, r):
         try:
             r._use_lua_lock = True
@@ -156,7 +156,7 @@ class TestLockClassSelection(object):
         finally:
             r._use_lua_lock = None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_cached_lock_flag(self, r):
         try:
             r._use_lua_lock = False
@@ -165,7 +165,7 @@ class TestLockClassSelection(object):
         finally:
             r._use_lua_lock = None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lua_compatible_server(self, r, monkeypatch):
         @classmethod
         def mock_register(cls, redis):
@@ -178,7 +178,7 @@ class TestLockClassSelection(object):
         finally:
             r._use_lua_lock = None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_lua_unavailable(self, r, monkeypatch):
         @classmethod
         def mock_register(cls, redis):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,7 +8,7 @@ from aredis.exceptions import (WatchError,
 
 class TestPipeline(object):
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pipeline(self, r):
         await r.flushdb()
         async with await r.pipeline() as pipe:
@@ -28,7 +28,7 @@ class TestPipeline(object):
                     [(b('z1'), 2.0), (b('z2'), 4)],
                 ]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pipeline_length(self, r):
         await r.flushdb()
         async with await r.pipeline() as pipe:
@@ -48,7 +48,7 @@ class TestPipeline(object):
             assert len(pipe) == 0
             assert not pipe
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pipeline_no_transaction(self, r):
         await r.flushdb()
         async with await r.pipeline(transaction=False) as pipe:
@@ -60,7 +60,7 @@ class TestPipeline(object):
             assert await r.get('b') == b('b1')
             assert await r.get('c') == b('c1')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pipeline_no_transaction_watch(self, r):
         await r.flushdb()
         await r.set('a', 0)
@@ -73,7 +73,7 @@ class TestPipeline(object):
             await pipe.set('a', int(a) + 1)
             assert await pipe.execute() == [True]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pipeline_no_transaction_watch_failure(self, r):
         await r.flushdb()
         await r.set('a', 0)
@@ -92,7 +92,7 @@ class TestPipeline(object):
 
             assert await r.get('a') == b('bad')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_exec_error_in_response(self, r):
         """
         an invalid pipeline command at exec time adds the exception instance
@@ -127,7 +127,7 @@ class TestPipeline(object):
             assert await pipe.execute() == [True]
             assert await r.get('z') == b('zzz')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_exec_error_raised(self, r):
         await r.flushdb()
         await r.set('c', 'a')
@@ -144,7 +144,7 @@ class TestPipeline(object):
             assert await pipe.execute() == [True]
             assert await r.get('z') == b('zzz')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_parse_error_raised(self, r):
         await r.flushdb()
         async with await r.pipeline() as pipe:
@@ -160,7 +160,7 @@ class TestPipeline(object):
             assert await pipe.execute() == [True]
             assert await r.get('z') == b('zzz')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_watch_succeed(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -179,7 +179,7 @@ class TestPipeline(object):
             assert await pipe.execute() == [True]
             assert not pipe.watching
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_watch_failure(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -195,7 +195,7 @@ class TestPipeline(object):
 
             assert not pipe.watching
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_unwatch(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -209,7 +209,7 @@ class TestPipeline(object):
             await pipe.get('a')
             assert await pipe.execute() == [b('1')]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_transaction_callable(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -235,7 +235,7 @@ class TestPipeline(object):
         assert result == [True]
         assert await r.get('c') == b('4')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_exec_error_in_no_transaction_pipeline(self, r):
         await r.flushdb()
         await r.set('a', 1)
@@ -248,7 +248,7 @@ class TestPipeline(object):
 
         assert await r.get('a') == b('1')
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_exec_error_in_no_transaction_pipeline_unicode_command(self, r):
         key = chr(11) + 'abcd' + chr(23)
         await r.set(key, 1)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -73,12 +73,12 @@ class TestPubSubSubscribeUnsubscribe(object):
             i = len(keys) - 1 - i
             assert await wait_for_message(p) == make_message(unsub_type, key, i)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_channel_subscribe_unsubscribe(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), 'channel')
         await self._test_subscribe_unsubscribe(**kwargs)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pattern_subscribe_unsubscribe(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), 'pattern')
         await self._test_subscribe_unsubscribe(**kwargs)
@@ -116,12 +116,12 @@ class TestPubSubSubscribeUnsubscribe(object):
             assert channel in keys
         await unsub_func()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_resubscribe_to_channels_on_reconnection(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), 'channel')
         await self._test_resubscribe_on_reconnection(**kwargs)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_resubscribe_to_patterns_on_reconnection(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), 'pattern')
         await self._test_resubscribe_on_reconnection(**kwargs)
@@ -173,17 +173,17 @@ class TestPubSubSubscribeUnsubscribe(object):
         assert p.subscribed is False
         await p.unsubscribe()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_subscribe_property_with_channels(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), 'channel')
         await self._test_subscribed_property(**kwargs)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_subscribe_property_with_patterns(self, r):
         kwargs = make_subscribe_test_data(r.pubsub(), 'pattern')
         await self._test_subscribed_property(**kwargs)
 
-    # @pytest.mark.asyncio
+    # @pytest.mark.asyncio(forbid_global_loop=True)
     # async def test_ignore_all_subscribe_messages(self, r):
     #     p = r.pubsub(ignore_subscribe_messages=True)
     #
@@ -202,7 +202,7 @@ class TestPubSubSubscribeUnsubscribe(object):
     #     assert p.subscribed is False
 
     # problem: pass in pycharm, but hang up in terminal
-    # @pytest.mark.asyncio
+    # @pytest.mark.asyncio(forbid_global_loop=True)
     # async def test_ignore_individual_subscribe_messages(self, r):
     #     p = r.pubsub()
     #
@@ -229,7 +229,7 @@ class TestPubSubMessages(object):
     def message_handler(self, message):
         self.message = message
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_published_message_to_channel(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
         await p.subscribe('foo')
@@ -241,7 +241,7 @@ class TestPubSubMessages(object):
         assert message == make_message('message', 'foo', 'test message')
         await p.unsubscribe()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_published_message_to_pattern(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
         await p.subscribe('foo')
@@ -264,7 +264,7 @@ class TestPubSubMessages(object):
         assert message1 != message2
         await p.unsubscribe('foo')
 
-    # @pytest.mark.asyncio
+    # @pytest.mark.asyncio(forbid_global_loop=True)
     # async def test_channel_message_handler(self, r):
     #     p = r.pubsub(ignore_subscribe_messages=True)
     #     await p.subscribe(foo=self.message_handler)
@@ -273,7 +273,7 @@ class TestPubSubMessages(object):
     #     assert self.message == make_message('message', 'foo', 'test message')
     #     await p.unsubscribe('foo')
     #
-    # @pytest.mark.asyncio
+    # @pytest.mark.asyncio(forbid_global_loop=True)
     # async def test_pattern_message_handler(self, r):
     #     p = r.pubsub(ignore_subscribe_messages=True)
     #     await p.psubscribe(**{'f*': self.message_handler})
@@ -283,7 +283,7 @@ class TestPubSubMessages(object):
     #                                         pattern='f*')
     #     await p.unsubscribe('foo')
 
-    # @pytest.mark.asyncio
+    # @pytest.mark.asyncio(forbid_global_loop=True)
     # async def test_unicode_channel_message_handler(self, r):
     #     p = r.pubsub(ignore_subscribe_messages=True)
     #     channel = 'uni' + chr(56) + 'code'
@@ -293,7 +293,7 @@ class TestPubSubMessages(object):
     #     assert await wait_for_message(p) is None
     #     assert self.message == make_message('message', channel, 'test message')
 
-    # @pytest.mark.asyncio
+    # @pytest.mark.asyncio(forbid_global_loop=True)
     # async def test_unicode_pattern_message_handler(self, r):
     #     p = r.pubsub(ignore_subscribe_messages=True)
     #     pattern = 'uni' + chr(56) + '*'
@@ -304,7 +304,7 @@ class TestPubSubMessages(object):
     #     assert self.message == make_message('pmessage', channel,
     #                                         'test message', pattern=pattern)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_get_message_without_subscribe(self, r):
         p = r.pubsub()
         with pytest.raises(RuntimeError) as info:
@@ -416,7 +416,7 @@ class TestPubSubMessages(object):
 #
 class TestPubSubRedisDown(object):
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_channel_subscribe(self, r):
         r = aredis.StrictRedis(host='localhost', port=6390)
         p = r.pubsub()
@@ -427,7 +427,7 @@ class TestPubSubRedisDown(object):
 class TestPubSubPubSubSubcommands(object):
 
     @skip_if_server_version_lt('2.8.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pubsub_channels(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
         await p.subscribe('foo', 'bar', 'baz', 'quux')
@@ -436,7 +436,7 @@ class TestPubSubPubSubSubcommands(object):
         await p.unsubscribe()
 
     @skip_if_server_version_lt('2.8.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pubsub_numsub(self, r):
         p1 = r.pubsub(ignore_subscribe_messages=True)
         await p1.subscribe('foo', 'bar', 'baz')
@@ -452,7 +452,7 @@ class TestPubSubPubSubSubcommands(object):
         await p3.unsubscribe()
 
     @skip_if_server_version_lt('2.8.0')
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pubsub_numpat(self, r):
         pubsub_count = await r.pubsub_numpat()
         p = r.pubsub(ignore_subscribe_messages=True)

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -25,21 +25,21 @@ return "hello " .. name
 
 class TestScripting(object):
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_eval(self, r):
         await r.flushdb()
         await r.set('a', 2)
         # 2 * 3 == 6
         assert await r.eval(multiply_script, 1, 'a', 3) == 6
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_evalsha(self, r):
         await r.set('a', 2)
         sha = await r.script_load(multiply_script)
         # 2 * 3 == 6
         assert await r.evalsha(sha, 1, 'a', 3) == 6
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_evalsha_script_not_loaded(self, r):
         await r.set('a', 2)
         sha = await r.script_load(multiply_script)
@@ -48,7 +48,7 @@ class TestScripting(object):
         with pytest.raises(NoScriptError):
             await r.evalsha(sha, 1, 'a', 3)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_script_loading(self, r):
         # get the sha, then clear the cache
         sha = await r.script_load(multiply_script)
@@ -57,7 +57,7 @@ class TestScripting(object):
         await r.script_load(multiply_script)
         assert await r.script_exists(sha) == [True]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_script_object(self, r):
         await r.set('a', 2)
         multiply = r.register_script(multiply_script)
@@ -69,7 +69,7 @@ class TestScripting(object):
         # test first evalsha
         assert await multiply.execute(keys=['a'], args=[3]) == 6
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_script_object_in_pipeline(self, r):
         multiply = r.register_script(multiply_script)
         assert not multiply.sha
@@ -97,7 +97,7 @@ class TestScripting(object):
         # [SET worked, GET 'a', result of multiple script]
         assert await pipe.execute() == [True, b('2'), 6]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_eval_msgpack_pipeline_error_in_lua(self, r):
         msgpack_hello = r.register_script(msgpack_hello_script)
         assert not msgpack_hello.sha


### PR DESCRIPTION
This pull request makes it so you can explicitly set the loop aredis should use for its connections. The tests now also check that the right loop is used. If no loop is given the original behavior is kept.
Tested on python 3.5 and 3.6 and redis: 3.2.7