### PR TITLE
[fix bug] pipeline callback executed

### DIFF
--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -3,6 +3,7 @@ import os
 import socket
 import ssl
 import sys
+import typing
 import warnings
 from io import BytesIO
 
@@ -400,7 +401,7 @@ class BaseConnection:
         # is for pubsub channel/pattern resubscription
         for callback in self._connect_callbacks:
             task = callback(self)
-            if isinstance(task, asyncio.coroutines.CoroWrapper):
+            if isinstance(task, typing.Awaitable):
                 await task
 
     async def _connect(self):

--- a/aredis/pipeline.py
+++ b/aredis/pipeline.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import typing
 from itertools import chain
 
 from aredis.client import (StrictRedisCluster, StrictRedis)
@@ -203,10 +204,9 @@ class BasePipeline(object):
                 command_name = args[0]
                 if command_name in self.response_callbacks:
                     callback = self.response_callbacks[command_name]
-                    if isinstance(callback, asyncio.coroutines.CoroWrapper):
-                        r = await callback(r, **options)
-                    else:
-                        r = callback(r, **options)
+                    r = callback(r, **options)
+                    if isinstance(response, typing.Awaitable):
+                        r = await r
             data.append(r)
         return data
 


### PR DESCRIPTION
* use `typing.Awaitable` instead of `asyncio.coroutines.CoroWrapper` & `types.CoroutineType` to judge the class of callback

* fix potential problem about callback of specific commands executed by pipeline