### PR TITLE
[fix bug] connection with unread response being released to connection pool

### DIFF
--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -370,6 +370,8 @@ class BaseConnection:
         self.encoding = encoding
         self.decode_responses = decode_responses
         self.loop = loop
+        # flag to show if a connection is waiting for response
+        self.awaiting_response = False
 
     def __repr__(self):
         return self.description.format(**self._description_args)
@@ -428,6 +430,8 @@ class BaseConnection:
         except TimeoutError:
             self.disconnect()
             raise
+        finally:
+            self.awaiting_response = False
         if isinstance(response, RedisError):
             raise response
         return response
@@ -461,6 +465,7 @@ class BaseConnection:
         if not (self._reader and self._writer):
             await self.connect()
         await self.send_packed_command(self.pack_command(*args))
+        self.awaiting_response = True
 
     def encode(self, value):
         "Return a bytestring representation of the value"

--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -430,8 +430,7 @@ class BaseConnection:
         except TimeoutError:
             self.disconnect()
             raise
-        finally:
-            self.awaiting_response = False
+        self.awaiting_response = False
         if isinstance(response, RedisError):
             raise response
         return response

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -216,7 +216,11 @@ class ConnectionPool(object):
         if connection.pid != self.pid:
             return
         self._in_use_connections.remove(connection)
-        self._available_connections.append(connection)
+        # discard connection with unread response
+        if connection.awaiting_response:
+            connection.disconnect()
+        else:
+            self._available_connections.append(connection)
 
     def disconnect(self):
         "Disconnects all connections in the pool"
@@ -383,7 +387,11 @@ class ClusterConnectionPool(ConnectionPool):
             i_c.remove(connection)
         else:
             pass
-        self._available_connections.setdefault(connection.node["name"], []).append(connection)
+        # discard connection with unread response
+        if connection.awaiting_response:
+            connection.disconnect()
+        else:
+            self._available_connections.setdefault(connection.node["name"], []).append(connection)
 
     def disconnect(self):
         """

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -218,6 +218,7 @@ class ConnectionPool(object):
         self._in_use_connections.remove(connection)
         # discard connection with unread response
         if connection.awaiting_response:
+            print('disconnect connection')
             connection.disconnect()
         else:
             self._available_connections.append(connection)
@@ -390,6 +391,9 @@ class ClusterConnectionPool(ConnectionPool):
         # discard connection with unread response
         if connection.awaiting_response:
             connection.disconnect()
+            # reduce node connection count in case of too many connection error raised
+            if self.max_connections_per_node and self._created_connections_per_node.get(connection.node['name']):
+                self._created_connections_per_node[connection.node['name']] -= 1
         else:
             self._available_connections.setdefault(connection.node["name"], []).append(connection)
 

--- a/tests/client/test_connection_pool.py
+++ b/tests/client/test_connection_pool.py
@@ -16,6 +16,7 @@ class DummyConnection(object):
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.pid = os.getpid()
+        self.awaiting_response = False
 
 
 class TestConnectionPool(object):

--- a/tests/cluster/test_cluster_connection_pool.py
+++ b/tests/cluster/test_cluster_connection_pool.py
@@ -34,6 +34,7 @@ class DummyConnection(object):
         self.host = host
         self.port = port
         self.socket_timeout = socket_timeout
+        self.awaiting_response = False
 
 
 class TestConnectionPool(object):


### PR DESCRIPTION
## phenomenon
As described in issue #52 , connection with unread response being released to connection pool and reused in next command, which leads to error during parsing response

## how to fix
1. Add flag attribute `awaiting_response` to connection and set it to `True` when waiting response
2. Discard connection with `awaiting_response` set to `True` when release connection