### PR TITLE
Fixbug init failed useing aws ssl cluster

### DIFF
--- a/aredis/client.py
+++ b/aredis/client.py
@@ -18,7 +18,7 @@ from aredis.commands.sets import SetsCommandMixin, ClusterSetsCommandMixin
 from aredis.commands.sorted_set import SortedSetCommandMixin, ClusterSortedSetCommandMixin
 from aredis.commands.strings import StringsCommandMixin, ClusterStringsCommandMixin
 from aredis.commands.transaction import TransactionCommandMixin, ClusterTransactionCommandMixin
-from aredis.connection import UnixDomainSocketConnection
+from aredis.connection import UnixDomainSocketConnection, RedisSSLContext
 from aredis.exceptions import (
     ConnectionError, TimeoutError,
     RedisClusterException, MovedError,
@@ -135,12 +135,8 @@ class StrictRedis(*mixins):
                 })
 
                 if ssl:
-                    kwargs.update({
-                        'ssl_keyfile': ssl_keyfile,
-                        'ssl_certfile': ssl_certfile,
-                        'ssl_cert_reqs': ssl_cert_reqs,
-                        'ssl_ca_certs': ssl_ca_certs,
-                    })
+                    ssl_context = RedisSSLContext(ssl_keyfile, ssl_certfile, ssl_cert_reqs, ssl_ca_certs).get()
+                    kwargs['ssl_context'] = ssl_context
             connection_pool = ConnectionPool(**kwargs)
         self.connection_pool = connection_pool
         self._use_lua_lock = None

--- a/aredis/client.py
+++ b/aredis/client.py
@@ -108,7 +108,7 @@ class StrictRedis(*mixins):
                  ssl_keyfile=None, ssl_certfile=None,
                  ssl_cert_reqs=None, ssl_ca_certs=None,
                  max_connections=None, retry_on_timeout=False,
-                 *, loop=None):
+                 loop=None, **kwargs):
         if not connection_pool:
             kwargs = {
                 'db': db,


### PR DESCRIPTION
### Description

issue: #68 

### change
* fix bug: initiation error of aws cluster client caused by not appropriate function list used.
* fix bug: use `ssl_context` instead of ssl_keyfile, ssl_certfile, ssl_cert_reqs, ssl_ca_certs in intialization of connection_pool(not using `from_url` method)