### PR TITLE
fix decrement connection count in cluster mode

### DIFF
--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -393,7 +393,7 @@ class ClusterConnectionPool(ConnectionPool):
         if connection.awaiting_response:
             connection.disconnect()
             # reduce node connection count in case of too many connection error raised
-            if self.max_connections_per_node and self._created_connections_per_node.get(connection.node['name']):
+            if self._created_connections_per_node.get(connection.node['name']):
                 self._created_connections_per_node[connection.node['name']] -= 1
         else:
             self._available_connections.setdefault(connection.node["name"], []).append(connection)


### PR DESCRIPTION
if not in max_connections_per_node, I will meet "Too many connections".

I try to read the source code which difference with redis-py-cluster.

I find this might be the problem.