### PR TITLE
Fix bug implicitly disconnection on cancelled error

### DIFF
--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -111,8 +111,7 @@ class PubSub(object):
             return await command(*args)
         except CancelledError:
             # do not retry if coroutine is cancelled
-            connection.disconnect()
-            return None
+            raise
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
             if not connection.retry_on_timeout and isinstance(e, TimeoutError):

--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -111,6 +111,10 @@ class PubSub(object):
             return await command(*args)
         except CancelledError:
             # do not retry if coroutine is cancelled
+            if await connection.can_read():
+                # disconnect if buffer is not empty in case of error
+                # when connection is reused
+                connection.disconnect()
             raise
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()

--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -115,7 +115,7 @@ class PubSub(object):
                 # disconnect if buffer is not empty in case of error
                 # when connection is reused
                 connection.disconnect()
-            raise
+            return None
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
             if not connection.retry_on_timeout and isinstance(e, TimeoutError):


### PR DESCRIPTION
## Description

See issue #56 and #80 
For now, when `CancelledError` is raised, only connection with not empty buffer will be disconnected. Useless re-connection and re-subscription will be leaved out.
