### PR TITLE
`parse_cluster_nodes` may fail for redis 4.0 and above

### DIFF
--- a/aredis/commands/cluster.py
+++ b/aredis/commands/cluster.py
@@ -62,7 +62,7 @@ def parse_cluster_nodes(resp, **options):
         node = {
             'id': self_id,
             'host': host or current_host,
-            'port': int(port),
+            'port': int(port.split('@')[0]),
             'flags': tuple(flags.split(',')),
             'master': master_id if master_id != '-' else None,
             'ping-sent': int(ping_sent),


### PR DESCRIPTION
I just opened [this ticket](https://github.com/antirez/redis/issues/5293) on `redis`, which describes a doc error in Redis for 4.0.0 and greater -- the `CLUSTER NODES` command output should actually be documented as containing `<ip:port@cport>` rather than `<ip:port>`. The new cluster port field seems to be a mandatory field as of Redis 4.0.0.

This causes [this line](https://github.com/NoneGG/aredis/blob/master/aredis/commands/cluster.py#L60) to set `port="6379@16379"` in the standard case, which then throws a ValueError [here](https://github.com/NoneGG/aredis/blob/master/aredis/commands/cluster.py#L65).