### PR TITLE
Allow users to configure acceptable waiting time in acquiring a new connection

### DIFF
--- a/aredis/client.py
+++ b/aredis/client.py
@@ -146,7 +146,7 @@ class StrictRedis(*mixins):
         "Execute a command and return a parsed response"
         pool = self.connection_pool
         command_name = args[0]
-        connection = pool.get_connection()
+        connection = await pool.get_connection()
         try:
             await connection.send_command(*args)
             return await self.parse_response(connection, command_name, **options)
@@ -380,9 +380,9 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
 
             if asking:
                 node = self.connection_pool.nodes.nodes[redirect_addr]
-                r = self.connection_pool.get_connection_by_node(node)
+                r = await self.connection_pool.get_connection_by_node(node)
             elif try_random_node:
-                r = self.connection_pool.get_random_connection()
+                r = await self.connection_pool.get_random_connection()
                 try_random_node = False
             else:
                 if self.refresh_table_asap:
@@ -390,7 +390,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
                     node = self.connection_pool.get_master_node_by_slot(slot)
                 else:
                     node = self.connection_pool.get_node_by_slot(slot)
-                r = self.connection_pool.get_connection_by_node(node)
+                r = await self.connection_pool.get_connection_by_node(node)
 
             try:
                 if asking:
@@ -438,7 +438,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
         res = {}
 
         for node in nodes:
-            connection = self.connection_pool.get_connection_by_node(node)
+            connection = await self.connection_pool.get_connection_by_node(node)
 
             # copy from redis-py
             try:

--- a/tests/client/test_connection_pool.py
+++ b/tests/client/test_connection_pool.py
@@ -29,31 +29,35 @@ class TestConnectionPool(object):
             **connection_kwargs)
         return pool
 
-    def test_connection_creation(self):
+    @pytest.mark.asyncio
+    async def test_connection_creation(self):
         connection_kwargs = {'foo': 'bar', 'biz': 'baz'}
         pool = self.get_pool(connection_kwargs=connection_kwargs)
-        connection = pool.get_connection()
+        connection = await pool.get_connection()
         assert isinstance(connection, DummyConnection)
         assert connection.kwargs == connection_kwargs
 
-    def test_multiple_connections(self):
+    @pytest.mark.asyncio
+    async def test_multiple_connections(self):
         pool = self.get_pool()
-        c1 = pool.get_connection()
-        c2 = pool.get_connection()
+        c1 = await pool.get_connection()
+        c2 = await pool.get_connection()
         assert c1 != c2
 
-    def test_max_connections(self):
+    @pytest.mark.asyncio
+    async def test_max_connections(self):
         pool = self.get_pool(max_connections=2)
-        pool.get_connection()
-        pool.get_connection()
+        await pool.get_connection()
+        await pool.get_connection()
         with pytest.raises(ConnectionError):
-            pool.get_connection()
+            await pool.get_connection()
 
-    def test_reuse_previously_released_connection(self):
+    @pytest.mark.asyncio
+    async def test_reuse_previously_released_connection(self):
         pool = self.get_pool()
-        c1 = pool.get_connection()
+        c1 = await pool.get_connection()
         pool.release(c1)
-        c2 = pool.get_connection()
+        c2 = await pool.get_connection()
         assert c1 == c2
 
     def test_repr_contains_db_info_tcp(self):
@@ -315,25 +319,26 @@ class TestSSLConnectionURLParsing(object):
             'password': None,
         }
 
-    def test_cert_reqs_options(self):
+    @pytest.mark.asyncio
+    async def test_cert_reqs_options(self):
         import ssl
         with pytest.raises(TypeError) as e:
             pool = aredis.ConnectionPool.from_url(
                 'rediss://?ssl_cert_reqs=none&ssl_keyfile=test')
             assert e.message == 'certfile should be a valid filesystem path'
-            assert pool.get_connection().ssl_context.verify_mode == ssl.CERT_NONE
+            assert await pool.get_connection().ssl_context.verify_mode == ssl.CERT_NONE
 
         with pytest.raises(TypeError) as e:
             pool = aredis.ConnectionPool.from_url(
                 'rediss://?ssl_cert_reqs=optional&ssl_keyfile=test')
             assert e.message == 'certfile should be a valid filesystem path'
-            assert pool.get_connection().ssl_context.verify_mode == ssl.CERT_OPTIONAL
+            assert await pool.get_connection().ssl_context.verify_mode == ssl.CERT_OPTIONAL
 
         with pytest.raises(TypeError) as e:
             pool = aredis.ConnectionPool.from_url(
                 'rediss://?ssl_cert_reqs=required&ssl_keyfile=test')
             assert e.message == 'certfile should be a valid filesystem path'
-            assert pool.get_connection().ssl_context.verify_mode == ssl.CERT_REQUIRED
+            assert await pool.get_connection().ssl_context.verify_mode == ssl.CERT_REQUIRED
 
 
 class TestConnection(object):


### PR DESCRIPTION
I am getting a lot of `RedisClusterException("Too many connections")`s and
want my client app to be able to control the concurrent connections a bit better.
I can across issue #51 which you closed saying the client should have control --
I completely agree! This PR does not change default `aredis` behaviour, but it
does allow clients of `aredis` to configure how they want `aredis` to behave in
this case.

This exposes the new parameter `wait_for_connection` (which defaults to `0`),
which is the amount of time an `aredis.ConnectionPool` will wait and attempt to
grab a connection before throwing an `Exception`.

Supports:
- `ConnectionPool(wait_for_connection: int = 0)`
- `ClusterConnectionPool(wait_for_connection: int = 0)`

and anything which initializes a pool:
- `StrictRedis(wait_for_connection: int = 0)`
- `StrictRedisCluster(wait_for_connection: int = 0)`
- `SentinelConnectionPool(wait_for_connection: int = 0)`
- etc...
