### PR TITLE
Fix accidentally disabled tests

### DIFF
--- a/aredis/nodemanager.py
+++ b/aredis/nodemanager.py
@@ -132,8 +132,7 @@ class NodeManager(object):
 
             # If there's only one server in the cluster, its ``host`` is ''
             # Fix it to the host in startup_nodes
-            if (len(cluster_slots) == 1
-                and len(self.startup_nodes) == 1):
+            if len(cluster_slots) == 1 and len(self.startup_nodes) == 1:
                 single_node_slots = cluster_slots.get((0, self.RedisClusterHashSlots - 1))[0]
                 if len(single_node_slots['host']) == 0:
                     single_node_slots['host'] = self.startup_nodes[0]['host']

--- a/aredis/pipeline.py
+++ b/aredis/pipeline.py
@@ -394,7 +394,7 @@ class StrictClusterPipeline(StrictRedisCluster):
                 raise r
 
     def annotate_exception(self, exception, number, command):
-        cmd = ' '.join(command)
+        cmd = ' '.join(str(x) for x in command)
         msg = 'Command # {0} ({1}) of pipeline caused error: {2}'.format(
             number, cmd, exception.args[0])
         exception.args = (msg,) + exception.args[1:]

--- a/docs/source/pubsub.rst
+++ b/docs/source/pubsub.rst
@@ -135,7 +135,7 @@ This makes it trivial to integrate into an existing event loop inside your appli
     >>>     message = await p.get_message()
     >>>     if message:
     >>>         # do something with the message
-    >>>     asyncio.sleep(0.001)  # be nice to the system :)
+    >>>     await asyncio.sleep(0.001)  # be nice to the system :)
 
 Older versions of aredis only read messages with `pubsub.listen()`. listen()
 is a generator that blocks until a message is available. If your application

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -9,6 +9,8 @@ All tests are built on the base of simplest redis server with default config.
 Redis server setup
 ^^^^^^^^^^^^^^^^^^
 
+To test against the latest stable redis server from source, use:
+
 .. code-block:: bash
 
     $ sudo apt-get update
@@ -21,6 +23,12 @@ Redis server setup
     $ make install
     $ sudo utils/install_server.sh
     $ sudo service redis_6379 start
+
+You can also use any version of Redis installed from your OS package manager (example for OSX: ``brew install redis``), in which case starting the server is as simple as running:
+
+.. code-block:: bash
+
+    $ redis-server
 
 
 StrictRedisCluster
@@ -35,6 +43,13 @@ Redis cluster setup
 ^^^^^^^^^^^^^^^^^^^
 
 A fully functional docker image can be found at https://github.com/Grokzen/docker-redis-cluster
+
+To turn on a cluster which should pass all tests, run:
+
+.. code-block:: bash
+
+    $ docker run --rm -it -p7000:7000 -p7001:7001 -p7002:7002 -p7003:7003 -p7004:7004 -p7005:7005 -e IP='0.0.0.0' grokzen/redis-cluster:latest
+
 
 Run test
 --------

--- a/tests/client/test_pubsub.py
+++ b/tests/client/test_pubsub.py
@@ -10,16 +10,12 @@ from .conftest import skip_if_server_version_lt
 
 
 async def wait_for_message(pubsub, timeout=0.1, ignore_subscribe_messages=False):
-    now = time.time()
-    timeout = now + timeout
-    while now < timeout:
-        message = await pubsub.get_message(
-            ignore_subscribe_messages=ignore_subscribe_messages)
-        if message is not None:
-            return message
-        time.sleep(0.01)
-        now = time.time()
-    return None
+    try:
+        return await pubsub.get_message(
+            ignore_subscribe_messages=ignore_subscribe_messages,
+            timeout=timeout)
+    except TimeoutError as e:
+        return None
 
 
 def make_message(type, channel, data, pattern=None):

--- a/tests/cluster/conftest.py
+++ b/tests/cluster/conftest.py
@@ -86,7 +86,9 @@ def o(request, *args, **kwargs):
     """
     Create a StrictRedisCluster instance with decode_responses set to True.
     """
-    return _get_client(cls=StrictRedisCluster, **kwargs)
+    params = {'decode_responses': True}
+    params.update(kwargs)
+    return _get_client(cls=StrictRedisCluster, **params)
 
 
 @pytest.fixture()

--- a/tests/cluster/test_cluster_connection_pool.py
+++ b/tests/cluster/test_cluster_connection_pool.py
@@ -222,10 +222,10 @@ class TestReadOnlyConnectionPool(object):
         """
         pool = await self.get_pool(connection_kwargs={})
 
-        expected_ports = {7000, 7003}
+        expected_ports = set(range(7000, 7006))
         actual_ports = set()
-        for _ in range(0, 100):
-            node = pool.get_node_by_slot(0)
+        for i in range(0, 16383):
+            node = pool.get_node_by_slot(i)
             actual_ports.add(node['port'])
         assert actual_ports == expected_ports
 

--- a/tests/cluster/test_cluster_obj.py
+++ b/tests/cluster/test_cluster_obj.py
@@ -118,7 +118,7 @@ class DummyConnection(object):
 #     assert not c.connection_pool.nodes.cluster_require_full_coverage.called
 #
 #
-# @pytest.mark.asyncio()
+# @pytest.mark.asyncio
 # async def test_blocked_commands(r):
 #     """
 #     These commands should be blocked and raise RedisClusterException
@@ -137,7 +137,7 @@ class DummyConnection(object):
 #         else:
 #             raise AssertionError("'RedisClusterException' not raised for method : {0}".format(command))
 #
-# @pytest.mark.asyncio()
+# @pytest.mark.asyncio
 # async def test_blocked_transaction(r):
 #     """
 #     Method transaction is blocked/NYI and should raise exception on use
@@ -147,7 +147,7 @@ class DummyConnection(object):
 #     assert str(ex.value).startswith("method StrictRedisCluster.transaction() is not implemented"), str(ex.value)
 #
 #
-# @pytest.mark.asyncio()
+# @pytest.mark.asyncio
 # async def test_cluster_of_one_instance():
 #     """
 #     Test a cluster that starts with only one redis server and ends up with
@@ -203,7 +203,7 @@ class DummyConnection(object):
 #             await rc.set('bar', 'foo')
 #
 #
-# @pytest.mark.asyncio()
+# @pytest.mark.asyncio
 # async def test_execute_command_errors(r):
 #     """
 #     If no command is given to `_determine_nodes` then exception
@@ -220,7 +220,7 @@ class DummyConnection(object):
 #     assert str(ex.value).startswith("No way to dispatch this command to Redis Cluster. Missing key.")
 #
 #
-# @pytest.mark.asyncio()
+# @pytest.mark.asyncio
 # async def test_refresh_table_asap(monkeypatch):
 #     """
 #     If this variable is set externally, initialize() should be called.
@@ -248,7 +248,7 @@ class DummyConnection(object):
 #         if node_name.endswith(port):
 #             return node_data['host']
 #
-# @pytest.mark.asyncio()
+# @pytest.mark.asyncio
 # async def test_ask_redirection():
 #     """
 #     Test that the server handles ASK response.
@@ -283,7 +283,7 @@ class DummyConnection(object):
 #         parse_response.side_effect = ask_redirect_effect
 #         assert await r.set("foo", "bar") == "MOCK_OK"
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_pipeline_ask_redirection():
     """
     Test that the server handles ASK response when used in pipeline.
@@ -323,7 +323,7 @@ async def test_pipeline_ask_redirection():
         await p.set("foo", "bar")
         assert await p.execute() == ["MOCK_OK"]
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_moved_redirection():
     """
     Test that the client handles MOVED response.
@@ -340,7 +340,7 @@ async def test_moved_redirection():
     assert await r0.set("foo", "bar")
     assert await r2.get('foo') == b'bar'
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_moved_redirection_pipeline(monkeypatch):
     """
     Test that the server handles MOVED response when used in pipeline.
@@ -365,7 +365,7 @@ async def assert_moved_redirection_on_slave(sr, connection_pool_cls, cluster_obj
     """
     # we assume this key is set on 127.0.0.1:7000(7003)
     await sr.set('foo16706', 'foo')
-    asyncio.sleep(1)
+    await asyncio.sleep(1)
 
     with patch.object(connection_pool_cls, 'get_node_by_slot') as return_slave_mock:
         return_slave_mock.return_value = {
@@ -382,7 +382,7 @@ async def assert_moved_redirection_on_slave(sr, connection_pool_cls, cluster_obj
             assert return_master_mock.call_count == 1
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_moved_redirection_on_slave_with_default_client(sr):
     """
     Test that the client is redirected normally with default
@@ -395,7 +395,7 @@ async def test_moved_redirection_on_slave_with_default_client(sr):
     )
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_moved_redirection_on_slave_with_readonly_mode_client(sr):
     """
     Ditto with READONLY mode.
@@ -407,7 +407,7 @@ async def test_moved_redirection_on_slave_with_readonly_mode_client(sr):
     )
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_access_correct_slave_with_readonly_mode_client(sr):
     """
     Test that the client can get value normally with readonly mode
@@ -416,7 +416,7 @@ async def test_access_correct_slave_with_readonly_mode_client(sr):
 
     # we assume this key is set on 127.0.0.1:7000(7003)
     await sr.set('foo16706', 'foo')
-    assert asyncio.sleep(1)
+    await asyncio.sleep(1)
 
     with patch.object(ClusterConnectionPool, 'get_node_by_slot') as return_slave_mock:
         return_slave_mock.return_value = {
@@ -433,4 +433,5 @@ async def test_access_correct_slave_with_readonly_mode_client(sr):
                 return_value=master_value) as return_master_mock:
             readonly_client = StrictRedisCluster(host="127.0.0.1", port=7000, readonly=True)
             assert b('foo') == await readonly_client.get('foo16706')
+            assert return_slave_mock.call_count == 1
             assert return_master_mock.call_count == 0

--- a/tests/cluster/test_node_manager.py
+++ b/tests/cluster/test_node_manager.py
@@ -2,6 +2,8 @@
 
 # python std lib
 from __future__ import with_statement
+import asyncio
+import uuid
 
 # rediscluster imports
 from tests.cluster.conftest import skip_if_server_version_lt
@@ -47,6 +49,7 @@ def test_keyslot():
     assert n.keyslot(str("abc")) == n.keyslot(b"abc")
 
 
+@pytest.mark.asyncio
 async def test_init_slots_cache_not_all_slots(s):
     """
     Test that if not all slots are covered it should raise an exception
@@ -60,11 +63,14 @@ async def test_init_slots_cache_not_all_slots(s):
         async def patch_execute_command(*args, **kwargs):
             if args == ('CLUSTER SLOTS',):
                 # Missing slot 5460
-                return [
-                    [0, 5459, [b'127.0.0.1', 7000], [b'127.0.0.1', 7003]],
-                    [5461, 10922, [b'127.0.0.1', 7001], [b'127.0.0.1', 7004]],
-                    [10923, 16383, [b'127.0.0.1', 7002], [b'127.0.0.1', 7005]],
-                ]
+                return {
+                    (0, 5459): [{'host': '127.0.0.1', 'port': 7000, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                                {'host': '127.0.0.1', 'port': 7003, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+                    (5461, 10922): [{'host': '127.0.0.1', 'port': 7001, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                                    {'host': '127.0.0.1', 'port': 7004, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+                    (10923, 16383): [{'host': '127.0.0.1', 'port': 7002, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                                    {'host': '127.0.0.1', 'port': 7005, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+                }
 
             return await orig_exec_method(*args, **kwargs)
 
@@ -78,9 +84,10 @@ async def test_init_slots_cache_not_all_slots(s):
     with pytest.raises(RedisClusterException) as ex:
         await s.connection_pool.initialize()
 
-    assert str(ex.value).startswith("All slots are not covered after query all startup_nodes.")
+    assert str(ex.value).startswith("Not all slots are covered after query all startup_nodes.")
 
 
+@pytest.mark.asyncio
 async def test_init_slots_cache_not_all_slots_not_require_full_coverage(s):
     """
     Test that if not all slots are covered it should raise an exception
@@ -91,18 +98,21 @@ async def test_init_slots_cache_not_all_slots_not_require_full_coverage(s):
 
         orig_exec_method = link.execute_command
 
-        def patch_execute_command(*args, **kwargs):
-            if args == ('cluster', 'slots'):
+        async def patch_execute_command(*args, **kwargs):
+            if args == ('CLUSTER SLOTS',):
                 # Missing slot 5460
-                return [
-                    [0, 5459, [b'127.0.0.1', 7000], [b'127.0.0.1', 7003]],
-                    [5461, 10922, [b'127.0.0.1', 7001], [b'127.0.0.1', 7004]],
-                    [10923, 16383, [b'127.0.0.1', 7002], [b'127.0.0.1', 7005]],
-                ]
+                return {
+                    (0, 5459): [{'host': '127.0.0.1', 'port': 7000, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                                {'host': '127.0.0.1', 'port': 7003, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+                    (5461, 10922): [{'host': '127.0.0.1', 'port': 7001, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                                    {'host': '127.0.0.1', 'port': 7004, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+                    (10923, 16383): [{'host': '127.0.0.1', 'port': 7002, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                                    {'host': '127.0.0.1', 'port': 7005, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+                }
             elif args == ('CONFIG GET', 'cluster-require-full-coverage'):
                 return {'cluster-require-full-coverage': 'no'}
             else:
-                return orig_exec_method(*args, **kwargs)
+                return await orig_exec_method(*args, **kwargs)
 
         # Missing slot 5460
         link.execute_command = patch_execute_command
@@ -116,18 +126,22 @@ async def test_init_slots_cache_not_all_slots_not_require_full_coverage(s):
     assert 5460 not in s.connection_pool.nodes.slots
 
 
+@pytest.mark.asyncio
 async def test_init_slots_cache(s):
     """
     Test that slots cache can in initialized and all slots are covered
     """
-    good_slots_resp = [
-        [0, 5460, [b'127.0.0.1', 7000], [b'127.0.0.2', 7003]],
-        [5461, 10922, [b'127.0.0.1', 7001], [b'127.0.0.2', 7004]],
-        [10923, 16383, [b'127.0.0.1', 7002], [b'127.0.0.2', 7005]],
-    ]
+    good_slots_resp = {
+        (0, 5460): [{'host': '127.0.0.1', 'port': 7000, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                    {'host': '127.0.0.1', 'port': 7003, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+        (5461, 10922): [{'host': '127.0.0.1', 'port': 7001, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                        {'host': '127.0.0.1', 'port': 7004, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+        (10923, 16383): [{'host': '127.0.0.1', 'port': 7002, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                        {'host': '127.0.0.1', 'port': 7005, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+    }
 
     with patch.object(StrictRedis, 'execute_command') as execute_command_mock:
-        def patch_execute_command(*args, **kwargs):
+        async def patch_execute_command(*args, **kwargs):
             if args == ('CONFIG GET', 'cluster-require-full-coverage'):
                 return {'cluster-require-full-coverage': 'yes'}
             else:
@@ -137,13 +151,13 @@ async def test_init_slots_cache(s):
 
         await s.connection_pool.nodes.initialize()
         assert len(s.connection_pool.nodes.slots) == NodeManager.RedisClusterHashSlots
-        for slot_info in good_slots_resp:
-            all_hosts = [b'127.0.0.1', b'127.0.0.2']
+        for slot_info, node_info in good_slots_resp.items():
+            all_hosts = ['127.0.0.1', '127.0.0.2']
             all_ports = [7000, 7001, 7002, 7003, 7004, 7005]
             slot_start = slot_info[0]
             slot_end = slot_info[1]
             for i in range(slot_start, slot_end + 1):
-                assert len(s.connection_pool.nodes.slots[i]) == len(slot_info[2:])
+                assert len(s.connection_pool.nodes.slots[i]) == len(node_info)
                 assert s.connection_pool.nodes.slots[i][0]['host'] in all_hosts
                 assert s.connection_pool.nodes.slots[i][1]['host'] in all_hosts
                 assert s.connection_pool.nodes.slots[i][0]['port'] in all_ports
@@ -171,6 +185,7 @@ def test_wrong_startup_nodes_type():
         NodeManager({})
 
 
+@pytest.mark.asyncio
 async def test_init_slots_cache_slots_collision():
     """
     Test that if 2 nodes do not agree on the same slots setup it should raise an error.
@@ -188,21 +203,27 @@ async def test_init_slots_cache_slots_collision():
         Helper function to return custom slots cache data from different redis nodes
         """
         if port == 7000:
-            result = [[0, 5460, [b'127.0.0.1', 7000], [b'127.0.0.1', 7003]],
-                      [5461, 10922, [b'127.0.0.1', 7001], [b'127.0.0.1', 7004]]]
-
+            result = {
+                (0, 5460): [{'host': '127.0.0.1', 'port': 7000, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                            {'host': '127.0.0.1', 'port': 7003, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+                (5461, 10922): [{'host': '127.0.0.1', 'port': 7001, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                                {'host': '127.0.0.1', 'port': 7004, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+            }
         elif port == 7001:
-            result = [[0, 5460, [b'127.0.0.1', 7001], [b'127.0.0.1', 7003]],
-                      [5461, 10922, [b'127.0.0.1', 7000], [b'127.0.0.1', 7004]]]
-
+            result = {
+                (0, 5460): [{'host': '127.0.0.1', 'port': 7001, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                            {'host': '127.0.0.1', 'port': 7003, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+                (5461, 10922): [{'host': '127.0.0.1', 'port': 7000, 'node_id': str(uuid.uuid4()), 'server_type': 'master'},
+                                {'host': '127.0.0.1', 'port': 7004, 'node_id': str(uuid.uuid4()), 'server_type': 'slave'}],
+            }
         else:
-            result = []
+            result = dict()
 
         r = StrictRedisCluster(host=host, port=port, decode_responses=True)
         orig_execute_command = r.execute_command
 
-        def execute_command(*args, **kwargs):
-            if args == ("cluster", "slots"):
+        async def execute_command(*args, **kwargs):
+            if args == ('CLUSTER SLOTS',):
                 return result
             elif args == ('CONFIG GET', 'cluster-require-full-coverage'):
                 return {'cluster-require-full-coverage': 'yes'}
@@ -218,6 +239,7 @@ async def test_init_slots_cache_slots_collision():
     assert str(ex.value).startswith("startup_nodes could not agree on a valid slots cache."), str(ex.value)
 
 
+@pytest.mark.asyncio
 async def test_all_nodes():
     """
     Set a list of nodes and it should be possible to itterate over all
@@ -231,6 +253,7 @@ async def test_all_nodes():
         assert node in nodes
 
 
+@pytest.mark.asyncio
 async def test_all_nodes_masters():
     """
     Set a list of nodes with random masters/slaves config and it shold be possible
@@ -257,6 +280,7 @@ def test_random_startup_node():
         assert random_node in s
 
 
+@pytest.mark.asyncio
 async def test_cluster_slots_error():
     """
     Check that exception is raised if initialize can't execute
@@ -289,42 +313,52 @@ def test_set_node():
     assert n.nodes == {expected['name']: expected}
 
 
-def test_reset():
+@pytest.mark.asyncio
+async def test_reset():
     """
     Test that reset method resets variables back to correct default values.
     """
+    class AsyncMock(Mock):
+        def __await__(self):
+            future = asyncio.Future(loop=asyncio.get_event_loop())
+            future.set_result(self)
+            result = yield from future
+            return result
+
     n = NodeManager(startup_nodes=[{}])
-    n.initialize = Mock()
-    n.reset()
-    assert n.initialize.call_count == 0
+    n.initialize = AsyncMock()
+    await n.reset()
+    assert n.initialize.call_count == 1
 
 
+@pytest.mark.asyncio
 async def test_cluster_one_instance():
     """
     If the cluster exists of only 1 node then there is some hacks that must
     be validated they work.
     """
     with patch.object(StrictRedis, 'execute_command') as mock_execute_command:
-        return_data = [[0, 16383, ['', 7006]]]
-
-        def patch_execute_command(*args, **kwargs):
+        async def patch_execute_command(*args, **kwargs):
             if args == ('CONFIG GET', 'cluster-require-full-coverage'):
                 return {'cluster-require-full-coverage': 'yes'}
             else:
-                return return_data
+                return {
+                    (0, 16383): [{'host': '', 'port': 7006, 'node_id': str(uuid.uuid4()), 'server_type': 'master'}],
+                }
 
-        # mock_execute_command.return_value = return_data
         mock_execute_command.side_effect = patch_execute_command
 
         n = NodeManager(startup_nodes=[{"host": "127.0.0.1", "port": 7006}])
         await n.initialize()
 
-        assert n.nodes == {"127.0.0.1:7006": {
-            'host': '127.0.0.1',
-            'name': '127.0.0.1:7006',
-            'port': 7006,
-            'server_type': 'master',
-        }}
+        del n.nodes['127.0.0.1:7006']['node_id']
+        assert n.nodes == {
+            "127.0.0.1:7006": {
+                'host': '127.0.0.1',
+                'name': '127.0.0.1:7006',
+                'port': 7006,
+                'server_type': 'master',
+            }}
 
         assert len(n.slots) == 16384
         for i in range(0, 16384):
@@ -336,12 +370,14 @@ async def test_cluster_one_instance():
             }]
 
 
+@pytest.mark.asyncio
 async def test_initialize_follow_cluster():
     n = NodeManager(nodemanager_follow_cluster=True, startup_nodes=[{'host': '127.0.0.1', 'port': 7000}])
     n.orig_startup_nodes = None
     await n.initialize()
 
 
+@pytest.mark.asyncio
 async def test_init_with_down_node():
     """
     If I can't connect to one of the nodes, everything should still work.

--- a/tests/cluster/test_scripting.py
+++ b/tests/cluster/test_scripting.py
@@ -109,6 +109,7 @@ class TestScripting(object):
         # test first evalsha
         assert await multiply.execute(keys=['a'], args=[3]) == 6
 
+    @pytest.mark.asyncio(forbid_global_loop=True)
     @pytest.mark.xfail(reason="Not Yet Implemented")
     async def test_script_object_in_pipeline(self, r):
         multiply = await r.register_script(multiply_script)
@@ -137,6 +138,7 @@ class TestScripting(object):
         # [SET worked, GET 'a', result of multiple script]
         assert await pipe.execute() == [True, b('2'), 6]
 
+    @pytest.mark.asyncio(forbid_global_loop=True)
     @pytest.mark.xfail(reason="Not Yet Implemented")
     async def test_eval_msgpack_pipeline_error_in_lua(self, r):
         msgpack_hello = await r.register_script(msgpack_hello_script)


### PR DESCRIPTION
A bunch of the `async` tests were not annotated with
`pytest.mark.async`, so they weren't being run. Turns out a bunch of
them are failing -- this commit turns them all on and fixes the simple
ones. Note there are no behaviour changes in this commit (besides the
bug fix listed below), so any tests failing on this branch **were
already failing on master, but had their output hidden**.

Bug Fixes:
- `annotate_exception`: don't break on `int` params

Test Fixes:
- `cluster/conftest.py:o`: ensure `decode_responses` is `True` as
described in docstring
- `TestReadOnlyConnectionPool::test_get_node_by_slot`: ensure cluster
nodes init order does not make test flaky
- Throughout: ensure `async` tests are actually run (if they don't have
`@pytest.mark.async`, they don't get run!)
- Throughout: ensure `async` methods called in tests are `await`ed
(otherwise, they become noops)
- `test_node_manager.py`: Fix `execute_commands` syntax for
`CLUSTER SLOTS` in previously not-run tests
- `test_pipeline.py`: fix pipeline syntax in previously not-run tests