### PR TITLE
chore(tests): add CircleCI matrix test config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,278 @@
+version: 2
+
+jobs:
+  python-3.5-client-3:
+    docker:
+      - image: python:3.5
+      - image: redis:3
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.5-client-4:
+    docker:
+      - image: python:3.5
+      - image: redis:4
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.5-client-5:
+    docker:
+      - image: python:3.5
+      - image: redis:5.0-rc
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.6-client-3:
+    docker:
+      - image: python:3.6
+      - image: redis:3
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.6-client-4:
+    docker:
+      - image: python:3.6
+      - image: redis:4
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.6-client-5:
+    docker:
+      - image: python:3.6
+      - image: redis:5.0-rc
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.5-cluster-3:
+    docker:
+      - image: python:3.5
+      - image: grokzen/redis-cluster:3.2.11
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.5-cluster-4:
+    docker:
+      - image: python:3.5
+      - image: grokzen/redis-cluster:4.0.9
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.5-cluster-5:
+    docker:
+      - image: python:3.5
+      - image: grokzen/redis-cluster:5.0-rc1
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.6-cluster-3:
+    docker:
+      - image: python:3.6
+      - image: grokzen/redis-cluster:3.2.11
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.6-cluster-4:
+    docker:
+      - image: python:3.6
+      - image: grokzen/redis-cluster:4.0.9
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.6-cluster-5:
+    docker:
+      - image: python:3.6
+      - image: grokzen/redis-cluster:5.0-rc1
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.5-client-3-hiredis:
+    docker:
+      - image: python:3.5
+      - image: redis:3
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.5-client-4-hiredis:
+    docker:
+      - image: python:3.5
+      - image: redis:4
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.5-client-5-hiredis:
+    docker:
+      - image: python:3.5
+      - image: redis:5.0-rc
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.6-client-3-hiredis:
+    docker:
+      - image: python:3.6
+      - image: redis:3
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.6-client-4-hiredis:
+    docker:
+      - image: python:3.6
+      - image: redis:4
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.6-client-5-hiredis:
+    docker:
+      - image: python:3.6
+      - image: redis:5.0-rc
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.5-cluster-3-hiredis:
+    docker:
+      - image: python:3.5
+      - image: grokzen/redis-cluster:3.2.11
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.5-cluster-4-hiredis:
+    docker:
+      - image: python:3.5
+      - image: grokzen/redis-cluster:4.0.9
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.5-cluster-5-hiredis:
+    docker:
+      - image: python:3.5
+      - image: grokzen/redis-cluster:5.0-rc1
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.6-cluster-3-hiredis:
+    docker:
+      - image: python:3.6
+      - image: grokzen/redis-cluster:3.2.11
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.6-cluster-4-hiredis:
+    docker:
+      - image: python:3.6
+      - image: grokzen/redis-cluster:4.0.9
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.6-cluster-5-hiredis:
+    docker:
+      - image: python:3.6
+      - image: grokzen/redis-cluster:5.0-rc1
+    steps:
+      - checkout
+      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+workflows:
+  version: 2
+  run-jobs:
+    jobs:
+      - python-3.5-client-3
+      - python-3.5-client-4
+      - python-3.5-client-5
+
+      - python-3.6-client-3
+      - python-3.6-client-4
+      - python-3.6-client-5
+
+      - python-3.5-cluster-3
+      - python-3.5-cluster-4
+      - python-3.5-cluster-5
+
+      - python-3.6-cluster-3
+      - python-3.6-cluster-4
+      - python-3.6-cluster-5
+
+      - python-3.5-client-3-hiredis
+      - python-3.5-client-4-hiredis
+      - python-3.5-client-5-hiredis
+
+      - python-3.6-client-3-hiredis
+      - python-3.6-client-4-hiredis
+      - python-3.6-client-5-hiredis
+
+      - python-3.5-cluster-3-hiredis
+      - python-3.5-cluster-4-hiredis
+      - python-3.5-cluster-5-hiredis
+
+      - python-3.6-cluster-3-hiredis
+      - python-3.6-cluster-4-hiredis
+      - python-3.6-cluster-5-hiredis

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - image: redis:3
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: pytest tests/client/
 
   python-3.5-client-4:
@@ -16,7 +16,7 @@ jobs:
       - image: redis:4
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: pytest tests/client/
 
   python-3.5-client-5:
@@ -25,7 +25,7 @@ jobs:
       - image: redis:5.0-rc
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: pytest tests/client/
 
   python-3.6-client-3:
@@ -34,7 +34,7 @@ jobs:
       - image: redis:3
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: pytest tests/client/
 
   python-3.6-client-4:
@@ -43,7 +43,7 @@ jobs:
       - image: redis:4
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: pytest tests/client/
 
   python-3.6-client-5:
@@ -52,7 +52,7 @@ jobs:
       - image: redis:5.0-rc
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: pytest tests/client/
 
   python-3.5-cluster-3:
@@ -61,7 +61,7 @@ jobs:
       - image: grokzen/redis-cluster:3.2.11
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
 
@@ -71,7 +71,7 @@ jobs:
       - image: grokzen/redis-cluster:4.0.9
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
 
@@ -81,7 +81,7 @@ jobs:
       - image: grokzen/redis-cluster:5.0-rc1
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
 
@@ -91,7 +91,7 @@ jobs:
       - image: grokzen/redis-cluster:3.2.11
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
 
@@ -101,7 +101,7 @@ jobs:
       - image: grokzen/redis-cluster:4.0.9
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
 
@@ -111,7 +111,7 @@ jobs:
       - image: grokzen/redis-cluster:5.0-rc1
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
 
@@ -121,7 +121,7 @@ jobs:
       - image: redis:3
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: pytest tests/client/
 
@@ -131,7 +131,7 @@ jobs:
       - image: redis:4
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: pytest tests/client/
 
@@ -141,7 +141,7 @@ jobs:
       - image: redis:5.0-rc
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: pytest tests/client/
 
@@ -151,7 +151,7 @@ jobs:
       - image: redis:3
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: pytest tests/client/
 
@@ -161,7 +161,7 @@ jobs:
       - image: redis:4
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: pytest tests/client/
 
@@ -171,7 +171,7 @@ jobs:
       - image: redis:5.0-rc
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: pytest tests/client/
 
@@ -181,7 +181,7 @@ jobs:
       - image: grokzen/redis-cluster:3.2.11
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
@@ -192,7 +192,7 @@ jobs:
       - image: grokzen/redis-cluster:4.0.9
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
@@ -203,7 +203,7 @@ jobs:
       - image: grokzen/redis-cluster:5.0-rc1
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
@@ -214,7 +214,7 @@ jobs:
       - image: grokzen/redis-cluster:3.2.11
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
@@ -225,7 +225,7 @@ jobs:
       - image: grokzen/redis-cluster:4.0.9
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
@@ -236,7 +236,7 @@ jobs:
       - image: grokzen/redis-cluster:5.0-rc1
     steps:
       - checkout
-      - run: python -m pip install -r dev_requirements.txt
+      - run: python -m pip install -r test_requirements.txt
       - run: python -m pip install hiredis
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 aredis
 ======
-|pypi-ver| |travis-status| |python-ver|
+|pypi-ver| |travis-status| |circleci-status| |python-ver|
 
 An efficient and user-friendly async redis client ported from `redis-py <https://github.com/andymccurdy/redis-py>`_
 (which is a Python interface to the Redis key-value)
@@ -100,6 +100,10 @@ Please run test script in benchmarks dir to confirm the benchmark.
 For benchmark in my environment please see: `benchmark`_
 
 .. _benchmark: http://aredis.readthedocs.io/en/latest/benchmark.html
+
+.. |circleci-status| image:: https://img.shields.io/circleci/project/github/NoneGG/aredis/master.svg
+    :alt: CircleCI build status
+    :target: https://circleci.com/gh/NoneGG/aredis/tree/master
 
 .. |travis-status| image:: https://travis-ci.org/NoneGG/aredis.png?branch=master
     :alt: Travis build status

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
-mock
-pytest
-pytest-asyncio
+-r test_requirements.txt
+hiredis
 uvloop

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,4 @@
-uvloop
-hiredis
+mock
 pytest
 pytest-asyncio
-mock
+uvloop

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,3 @@
+mock
+pytest
+pytest-asyncio


### PR DESCRIPTION
@NoneGG As described in #95, here is a CircleCI config if
you want it. This will matrix test:
- python 3.5 vs 3.6
- redis 3 vs 4 vs 5(-rc)
- client and cluster
- hiredis and not

I also noticed that you had `hiredis` in your
`dev_requirements.txt`, so the Travis tests which were marked
`TEST_HIREDIS=0` would have still had it installed.