### PR TITLE
Support SSL for StrictRedisCluster client

### DIFF
--- a/aredis/client.py
+++ b/aredis/client.py
@@ -95,7 +95,7 @@ class StrictRedis(*mixins):
                  db=0, password=None, stream_timeout=None,
                  connect_timeout=None, connection_pool=None,
                  unix_socket_path=None, encoding='utf-8',
-                 decode_responses=False, ssl=False,
+                 decode_responses=False, ssl=False, ssl_context=None,
                  ssl_keyfile=None, ssl_certfile=None,
                  ssl_cert_reqs=None, ssl_ca_certs=None,
                  max_connections=None, retry_on_timeout=False,
@@ -124,8 +124,9 @@ class StrictRedis(*mixins):
                     'host': host,
                     'port': port
                 })
-
-                if ssl:
+                if ssl_context is not None:
+                    kwargs['ssl_context'] = ssl_context
+                elif ssl:
                     ssl_context = RedisSSLContext(ssl_keyfile, ssl_certfile, ssl_cert_reqs, ssl_ca_certs).get()
                     kwargs['ssl_context'] = ssl_context
             connection_pool = ConnectionPool(**kwargs)

--- a/aredis/nodemanager.py
+++ b/aredis/nodemanager.py
@@ -92,7 +92,8 @@ class NodeManager(object):
             'ssl_context',
             'parser_class',
             'reader_read_size',
-            'loop'
+            'loop',
+            'ssl'
         )
         connection_kwargs = {k: v for k, v in self.connection_kwargs.items() if k in allowed_keys}
         return StrictRedis(host=host, port=port, decode_responses=True, **connection_kwargs)

--- a/aredis/nodemanager.py
+++ b/aredis/nodemanager.py
@@ -92,8 +92,7 @@ class NodeManager(object):
             'ssl_context',
             'parser_class',
             'reader_read_size',
-            'loop',
-            'ssl'
+            'loop'
         )
         connection_kwargs = {k: v for k, v in self.connection_kwargs.items() if k in allowed_keys}
         return StrictRedis(host=host, port=port, decode_responses=True, **connection_kwargs)


### PR DESCRIPTION
#### Description

Current release supports SSL for StrictRedis client only. If we use this approach to StrictRedisCluster, it will not success. 

Long detail explain:
1. To create StrictRedisCluster with SSL mode, we could pass either `ssl_context` or set of params `ssl`, `ssl_keyfile`, `ssl_certfile`, `ssl_cert_reqs`, and `ssl_ca_certs` into its constructor.
2. Inside cluster instance, it holds a NodeManage which inherits all kwarg from StrictRedisCluster on step 1. 
So NodeManage will probably own `ssl_context`, and set of params `ssl`, `ssl_keyfile`, `ssl_certfile, `ssl_cert_reqs`, and `ssl_ca_certs`.
3. NodeManager initializes and use only `ssl_context` to check whether startup node is reachable or not. => In this step, set of parameters `ssl`, `ssl_keyfile`, `ssl_certfile`, `ssl_cert_reqs`, and `ssl_ca_certs` is completely ignored.
This case will not work, because StrictRedis constructor doesn't accept `ssl_context` param unless you pass `connection_pool`

In conclusion, I enable StrictRedis accept both `ssl_context` and set of ssl parameters in case `connection_pool` is empty.

#102  -> resolved