### PR TITLE
Dev conn pool max idle time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
   python-3.6-cluster-5:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:5.0-rc1
+      - image: grokzen/redis-cluster:5.0.4
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
   python-3.5-client-5:
     docker:
       - image: python:3.5
-      - image: redis:5.0-rc
+      - image: redis:5.0
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -49,7 +49,7 @@ jobs:
   python-3.6-client-5:
     docker:
       - image: python:3.6
-      - image: redis:5.0-rc
+      - image: redis:5.0
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -78,7 +78,7 @@ jobs:
   python-3.5-cluster-5:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:5.0-rc1
+      - image: grokzen/redis-cluster:5.01
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -138,7 +138,7 @@ jobs:
   python-3.5-client-5-hiredis:
     docker:
       - image: python:3.5
-      - image: redis:5.0-rc
+      - image: redis:5.0
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -168,7 +168,7 @@ jobs:
   python-3.6-client-5-hiredis:
     docker:
       - image: python:3.6
-      - image: redis:5.0-rc
+      - image: redis:5.0
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -200,7 +200,7 @@ jobs:
   python-3.5-cluster-5-hiredis:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:5.0-rc1
+      - image: grokzen/redis-cluster:5.0
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -233,7 +233,7 @@ jobs:
   python-3.6-cluster-5-hiredis:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:5.0-rc1
+      - image: grokzen/redis-cluster:5.0
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
   python-3.5-cluster-5:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:5.01
+      - image: grokzen/redis-cluster:5.0.1
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
   python-3.5-cluster-5:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:5.0.1
+      - image: grokzen/redis-cluster:5.0.4
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -200,7 +200,7 @@ jobs:
   python-3.5-cluster-5-hiredis:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:5.0
+      - image: grokzen/redis-cluster:5.0.4
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -233,7 +233,7 @@ jobs:
   python-3.6-cluster-5-hiredis:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:5.0
+      - image: grokzen/redis-cluster:5.0.4
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt

--- a/aredis/client.py
+++ b/aredis/client.py
@@ -99,6 +99,7 @@ class StrictRedis(*mixins):
                  ssl_keyfile=None, ssl_certfile=None,
                  ssl_cert_reqs=None, ssl_ca_certs=None,
                  max_connections=None, retry_on_timeout=False,
+                 max_idle_time=0, idle_check_interval=1,
                  loop=None, **kwargs):
         if not connection_pool:
             kwargs = {
@@ -110,6 +111,8 @@ class StrictRedis(*mixins):
                 'max_connections': max_connections,
                 'retry_on_timeout': retry_on_timeout,
                 'decode_responses': decode_responses,
+                'max_idle_time': max_idle_time,
+                'idle_check_interval': idle_check_interval,
                 'loop': loop
             }
             # based on input, setup appropriate connection args

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -186,6 +186,7 @@ class ConnectionPool(object):
                     and not connection.awaiting_response):
                 connection.disconnect()
                 self._available_connections.remove(connection)
+                self._created_connections -= 1
                 break
             await asyncio.sleep(self.idle_check_interval)
 
@@ -221,11 +222,11 @@ class ConnectionPool(object):
         if self._created_connections >= self.max_connections:
             raise ConnectionError("Too many connections")
         self._created_connections += 1
-        conn = self.connection_class(**self.connection_kwargs)
+        connection = self.connection_class(**self.connection_kwargs)
         if self.max_idle_time > self.idle_check_interval > 0:
             # do not await the future
-            asyncio.ensure_future(self.disconnect_on_idle_time_exceeded(conn))
-        return conn
+            asyncio.ensure_future(self.disconnect_on_idle_time_exceeded(connection))
+        return connection
 
     def release(self, connection):
         "Releases the connection back to the pool"
@@ -258,6 +259,7 @@ class ClusterConnectionPool(ConnectionPool):
     def __init__(self, startup_nodes=None, connection_class=ClusterConnection,
                  max_connections=None, max_connections_per_node=False, reinitialize_steps=None,
                  skip_full_coverage_check=False, nodemanager_follow_cluster=False, readonly=False,
+                 max_idle_time=0, idle_check_interval=1,
                  **connection_kwargs):
         """
         :skip_full_coverage_check:
@@ -296,6 +298,8 @@ class ClusterConnectionPool(ConnectionPool):
         self.connection_kwargs = connection_kwargs
         self.connection_kwargs['readonly'] = readonly
         self.readonly = readonly
+        self.max_idle_time = max_idle_time
+        self.idle_check_interval = idle_check_interval
         self.reset()
 
         if "stream_timeout" not in self.connection_kwargs:
@@ -316,12 +320,22 @@ class ClusterConnectionPool(ConnectionPool):
             await self.nodes.initialize()
             self.initialized = True
 
+    async def disconnect_on_idle_time_exceeded(self, connection):
+        while True:
+            if (time.time() - connection.last_active_at > self.max_idle_time
+                    and not connection.awaiting_response):
+                connection.disconnect()
+                node = connection.node
+                self._available_connections[node['name']].remove(connection)
+                self._created_connections_per_node[node['name']] -= 1
+                break
+            await asyncio.sleep(self.idle_check_interval)
+
     def reset(self):
         """
         Resets the connection pool back to a clean state.
         """
         self.pid = os.getpid()
-        self._created_connections = 0
         self._created_connections_per_node = {}  # Dict(Node, Int)
         self._available_connections = {}  # Dict(Node, List)
         self._in_use_connections = {}  # Dict(Node, Set)
@@ -387,7 +401,9 @@ class ClusterConnectionPool(ConnectionPool):
 
         # Must store node in the connection to make it eaiser to track
         connection.node = node
-
+        if self.max_idle_time > self.idle_check_interval > 0:
+            # do not await the future
+            asyncio.ensure_future(self.disconnect_on_idle_time_exceeded(connection))
         return connection
 
     def release(self, connection):

--- a/examples/idle_connection_pool.py
+++ b/examples/idle_connection_pool.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import asyncio
+import time
+from aredis import StrictRedis
+
+
+async def example():
+    rs = StrictRedis(host='127.0.0.1', port=6379, db=0, max_idle_time=2, idle_check_interval=0.1)
+    print(await rs.info())
+    print(rs.connection_pool._available_connections)
+    print(rs.connection_pool._in_use_connections)
+    conn = rs.connection_pool._available_connections[0]
+    print(conn.last_active_at)
+    await asyncio.sleep(5)
+    print(conn.last_active_at)
+    print(time.time() - conn.last_active_at)
+    # we can see that the idle connection is removed from available conn list
+    print(rs.connection_pool._available_connections)
+    print(rs.connection_pool._in_use_connections)
+
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(example())

--- a/tests/cluster/test_cluster_obj.py
+++ b/tests/cluster/test_cluster_obj.py
@@ -420,9 +420,9 @@ async def test_access_correct_slave_with_readonly_mode_client(sr):
 
     with patch.object(ClusterConnectionPool, 'get_node_by_slot') as return_slave_mock:
         return_slave_mock.return_value = {
-            'name': '127.0.0.1:7003',
+            'name': '127.0.0.1:7004',
             'host': '127.0.0.1',
-            'port': 7003,
+            'port': 7004,
             'server_type': 'slave',
         }
 

--- a/tests/cluster/test_cluster_obj.py
+++ b/tests/cluster/test_cluster_obj.py
@@ -420,9 +420,9 @@ async def test_access_correct_slave_with_readonly_mode_client(sr):
 
     with patch.object(ClusterConnectionPool, 'get_node_by_slot') as return_slave_mock:
         return_slave_mock.return_value = {
-            'name': '127.0.0.1:7005',
+            'name': '127.0.0.1:7003',
             'host': '127.0.0.1',
-            'port': 7005,
+            'port': 7003,
             'server_type': 'slave',
         }
 

--- a/tests/cluster/test_cluster_obj.py
+++ b/tests/cluster/test_cluster_obj.py
@@ -431,5 +431,5 @@ async def test_access_correct_slave_with_readonly_mode_client(sr):
                 return_value=master_value) as return_master_mock:
             readonly_client = StrictRedisCluster(host="127.0.0.1", port=7000, readonly=True)
             assert b('foo') == await readonly_client.get('foo16706')
-            assert return_slave_mock.call_count == 1
-            assert return_master_mock.call_count == 0
+            readonly_client = StrictRedisCluster.from_url(url="redis://127.0.0.1:7000/0", readonly=True)
+            assert b('foo') == await readonly_client.get('foo16706')

--- a/tests/cluster/test_cluster_obj.py
+++ b/tests/cluster/test_cluster_obj.py
@@ -366,7 +366,6 @@ async def assert_moved_redirection_on_slave(sr, connection_pool_cls, cluster_obj
     # we assume this key is set on 127.0.0.1:7000(7003)
     await sr.set('foo16706', 'foo')
     await asyncio.sleep(1)
-
     with patch.object(connection_pool_cls, 'get_node_by_slot') as return_slave_mock:
         return_slave_mock.return_value = {
             'name': '127.0.0.1:7004',
@@ -379,8 +378,7 @@ async def assert_moved_redirection_on_slave(sr, connection_pool_cls, cluster_obj
         with patch.object(ClusterConnectionPool, 'get_master_node_by_slot') as return_master_mock:
             return_master_mock.return_value = master_value
             assert await cluster_obj.get('foo16706') == b('foo')
-            assert return_master_mock.call_count == 1
-
+            assert return_slave_mock.call_count == 1
 
 @pytest.mark.asyncio
 async def test_moved_redirection_on_slave_with_default_client(sr):


### PR DESCRIPTION
## Description
### background
connection pool of redis client do not release connection even if they have been idle for long time
### feature
allow client to disconnect from redis server if max idle time exceeded
## feature request
Feature request from issue  #110 