### PR TITLE
Fixbug threading local in coroutine

### DIFF
--- a/aredis/utils.py
+++ b/aredis/utils.py
@@ -1,8 +1,7 @@
 import sys
 from functools import wraps
 
-from aredis.exceptions import (RedisClusterException,
-                               ClusterDownError)
+from aredis.exceptions import (ClusterDownError, RedisClusterException)
 
 _C_EXTENSION_SPEEDUP = False
 try:
@@ -56,7 +55,15 @@ class dummy(object):
     """
     Instances of this class can be used as an attribute container.
     """
-    pass
+
+    def __init__(self):
+        self.token = None
+
+    def set(self, value):
+        self.token = value
+
+    def get(self):
+        return self.token
 
 
 # ++++++++++ response callbacks ++++++++++++++

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
 -r test_requirements.txt
 hiredis
 uvloop
+contextvars

--- a/setup.py
+++ b/setup.py
@@ -137,5 +137,12 @@ setup(
     ext_modules=[
         Extension(name='aredis.speedups',
                   sources=['aredis/speedups.c']),
+    ],
+    # The good news is that the standard library always
+    # takes the precedence over site packages,
+    # so even if a local contextvars module is installed,
+    # the one from the standard library will be used.
+    install_requires=[
+        'contextvars;python_version<"3.7"'
     ]
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 mock
 pytest
 pytest-asyncio
+contextvars

--- a/tests/client/test_lock.py
+++ b/tests/client/test_lock.py
@@ -138,12 +138,12 @@ class TestLock(object):
 
     @pytest.mark.asyncio()
     async def test_concurrent_lock_acquire(self, r):
-        lock = self.get_lock(r, 'test', timeout=0.5)
+        lock = self.get_lock(r, 'test', timeout=1)
 
         async def coro(lock):
             is_error_raised = False
             await lock.acquire(blocking=True)
-            await asyncio.sleep(1)
+            await asyncio.sleep(1.5)
             try:
                 await lock.release()
             except LockError as exc:

--- a/tests/client/test_lock.py
+++ b/tests/client/test_lock.py
@@ -1,6 +1,9 @@
 from __future__ import with_statement
-import pytest
+
+import asyncio
 import time
+
+import pytest
 
 from aredis.exceptions import LockError, ResponseError
 from aredis.lock import Lock, LuaLock
@@ -18,7 +21,7 @@ class TestLock(object):
         await r.flushdb()
         lock = self.get_lock(r, 'foo')
         assert await lock.acquire(blocking=False)
-        assert await r.get('foo') == lock.local.token
+        assert await r.get('foo') == lock.local.get()
         assert await r.ttl('foo') == -1
         await lock.release()
         assert await r.get('foo') is None
@@ -63,7 +66,7 @@ class TestLock(object):
         # blocking_timeout prevents a deadlock if the lock can't be acquired
         # for some reason
         async with self.get_lock(r, 'foo', blocking_timeout=0.2) as lock:
-            assert await r.get('foo') == lock.local.token
+            assert await r.get('foo') == lock.local.get()
         assert await r.get('foo') is None
 
     @pytest.mark.asyncio()
@@ -87,7 +90,7 @@ class TestLock(object):
         with pytest.raises(LockError):
             await lock.release()
         # even though we errored, the token is still cleared
-        assert lock.local.token is None
+        assert lock.local.get() is None
 
     @pytest.mark.asyncio()
     async def test_extend_lock(self, r):
@@ -133,6 +136,23 @@ class TestLock(object):
         with pytest.raises(LockError):
             await lock.extend(10)
 
+    @pytest.mark.asyncio()
+    async def test_concurrent_lock_acquire(self, r):
+        lock = self.get_lock(r, 'test', timeout=0.5)
+
+        async def coro(lock):
+            is_error_raised = False
+            await lock.acquire(blocking=True)
+            await asyncio.sleep(1)
+            try:
+                await lock.release()
+            except LockError as exc:
+                is_error_raised = True
+            return is_error_raised
+
+        results = await asyncio.gather(coro(lock), coro(lock))
+        assert not (results[0] and results[1])
+
 
 class TestLuaLock(TestLock):
     lock_class = LuaLock
@@ -170,6 +190,7 @@ class TestLockClassSelection(object):
         @classmethod
         def mock_register(cls, redis):
             return
+
         monkeypatch.setattr(LuaLock, 'register_scripts', mock_register)
         try:
             lock = r.lock('foo')
@@ -183,6 +204,7 @@ class TestLockClassSelection(object):
         @classmethod
         def mock_register(cls, redis):
             raise ResponseError()
+
         monkeypatch.setattr(LuaLock, 'register_scripts', mock_register)
         try:
             lock = r.lock('foo')

--- a/tests/cluster/test_lock.py
+++ b/tests/cluster/test_lock.py
@@ -16,7 +16,7 @@ class TestLock(object):
         await r.flushdb()
         lock = self.get_lock(r, 'foo', timeout=3)
         assert await lock.acquire(blocking=False)
-        assert await r.get('foo') == lock.local.token
+        assert await r.get('foo') == lock.local.get()
         assert await r.ttl('foo') == 3
         await lock.release()
         assert await r.get('foo') is None
@@ -61,7 +61,7 @@ class TestLock(object):
         # blocking_timeout prevents a deadlock if the lock can't be acquired
         # for some reason
         async with self.get_lock(r, 'foo', timeout=3, blocking_timeout=0.2) as lock:
-            assert await r.get('foo') == lock.local.token
+            assert await r.get('foo') == lock.local.get()
         assert await r.get('foo') is None
 
     @pytest.mark.asyncio()
@@ -85,7 +85,7 @@ class TestLock(object):
         with pytest.raises(LockError):
             await lock.release()
         # even though we errored, the token is still cleared
-        assert lock.local.token is None
+        assert lock.local.get() is None
 
     @pytest.mark.asyncio()
     async def test_extend_lock(self, r):


### PR DESCRIPTION
## Description

New: use contextvars instead of threading local in case of the safety of thread local mechanism being broken by coroutines

related issue #119 