### PR TITLE
fix: importation of CancelledError with Python 3.7+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
   python-3.5-cluster-3:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:3.2.11
+      - image: grokzen/redis-cluster:3.2.13
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -122,7 +122,7 @@ jobs:
   python-3.5-cluster-4:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:4.0.9
+      - image: grokzen/redis-cluster:4.0.14
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -132,7 +132,7 @@ jobs:
   python-3.5-cluster-5:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:5.0.4
+      - image: grokzen/redis-cluster:5.0.5
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -142,7 +142,7 @@ jobs:
   python-3.6-cluster-3:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:3.2.11
+      - image: grokzen/redis-cluster:3.2.13
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -152,7 +152,7 @@ jobs:
   python-3.6-cluster-4:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:4.0.9
+      - image: grokzen/redis-cluster:4.0.14
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -162,7 +162,7 @@ jobs:
   python-3.6-cluster-5:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:5.0.4
+      - image: grokzen/redis-cluster:5.0.5
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -172,7 +172,7 @@ jobs:
   python-3.7-cluster-3:
     docker:
       - image: python:3.7
-      - image: grokzen/redis-cluster:3.2.11
+      - image: grokzen/redis-cluster:3.2.13
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -182,7 +182,7 @@ jobs:
   python-3.7-cluster-4:
     docker:
       - image: python:3.7
-      - image: grokzen/redis-cluster:4.0.9
+      - image: grokzen/redis-cluster:4.0.14
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -192,7 +192,7 @@ jobs:
   python-3.7-cluster-5:
     docker:
       - image: python:3.7
-      - image: grokzen/redis-cluster:5.0.4
+      - image: grokzen/redis-cluster:5.0.5
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -202,7 +202,7 @@ jobs:
   python-3.8-cluster-3:
     docker:
       - image: python:3.8
-      - image: grokzen/redis-cluster:3.2.11
+      - image: grokzen/redis-cluster:3.2.13
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -212,7 +212,7 @@ jobs:
   python-3.8-cluster-4:
     docker:
       - image: python:3.8
-      - image: grokzen/redis-cluster:4.0.9
+      - image: grokzen/redis-cluster:4.0.14
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -222,7 +222,7 @@ jobs:
   python-3.8-cluster-5:
     docker:
       - image: python:3.8
-      - image: grokzen/redis-cluster:5.0.4
+      - image: grokzen/redis-cluster:5.0.5
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -352,7 +352,7 @@ jobs:
   python-3.5-cluster-3-hiredis:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:3.2.11
+      - image: grokzen/redis-cluster:3.2.13
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -363,7 +363,7 @@ jobs:
   python-3.5-cluster-4-hiredis:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:4.0.9
+      - image: grokzen/redis-cluster:4.0.14
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -374,7 +374,7 @@ jobs:
   python-3.5-cluster-5-hiredis:
     docker:
       - image: python:3.5
-      - image: grokzen/redis-cluster:5.0.4
+      - image: grokzen/redis-cluster:5.0.5
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -385,7 +385,7 @@ jobs:
   python-3.6-cluster-3-hiredis:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:3.2.11
+      - image: grokzen/redis-cluster:3.2.13
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -396,7 +396,7 @@ jobs:
   python-3.6-cluster-4-hiredis:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:4.0.9
+      - image: grokzen/redis-cluster:4.0.14
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -407,7 +407,7 @@ jobs:
   python-3.6-cluster-5-hiredis:
     docker:
       - image: python:3.6
-      - image: grokzen/redis-cluster:5.0.4
+      - image: grokzen/redis-cluster:5.0.5
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -418,7 +418,7 @@ jobs:
   python-3.7-cluster-3-hiredis:
     docker:
       - image: python:3.7
-      - image: grokzen/redis-cluster:3.2.11
+      - image: grokzen/redis-cluster:3.2.13
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -429,7 +429,7 @@ jobs:
   python-3.7-cluster-4-hiredis:
     docker:
       - image: python:3.7
-      - image: grokzen/redis-cluster:4.0.9
+      - image: grokzen/redis-cluster:4.0.14
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -440,7 +440,7 @@ jobs:
   python-3.7-cluster-5-hiredis:
     docker:
       - image: python:3.7
-      - image: grokzen/redis-cluster:5.0.4
+      - image: grokzen/redis-cluster:5.0.5
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -451,7 +451,7 @@ jobs:
   python-3.8-cluster-3-hiredis:
     docker:
       - image: python:3.8
-      - image: grokzen/redis-cluster:3.2.11
+      - image: grokzen/redis-cluster:3.2.13
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -462,7 +462,7 @@ jobs:
   python-3.8-cluster-4-hiredis:
     docker:
       - image: python:3.8
-      - image: grokzen/redis-cluster:4.0.9
+      - image: grokzen/redis-cluster:4.0.14
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt
@@ -473,7 +473,7 @@ jobs:
   python-3.8-cluster-5-hiredis:
     docker:
       - image: python:3.8
-      - image: grokzen/redis-cluster:5.0.4
+      - image: grokzen/redis-cluster:5.0.5
     steps:
       - checkout
       - run: python -m pip install -r test_requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,60 @@ jobs:
       - run: python -m pip install -r test_requirements.txt
       - run: pytest tests/client/
 
+  python-3.7-client-3:
+    docker:
+      - image: python:3.7
+      - image: redis:3
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.7-client-4:
+    docker:
+      - image: python:3.7
+      - image: redis:4
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.7-client-5:
+    docker:
+      - image: python:3.7
+      - image: redis:5.0
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.8-client-3:
+    docker:
+      - image: python:3.8
+      - image: redis:3
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.8-client-4:
+    docker:
+      - image: python:3.8
+      - image: redis:4
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: pytest tests/client/
+
+  python-3.8-client-5:
+    docker:
+      - image: python:3.8
+      - image: redis:5.0
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: pytest tests/client/
+
   python-3.5-cluster-3:
     docker:
       - image: python:3.5
@@ -115,6 +169,66 @@ jobs:
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
 
+  python-3.7-cluster-3:
+    docker:
+      - image: python:3.7
+      - image: grokzen/redis-cluster:3.2.11
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.7-cluster-4:
+    docker:
+      - image: python:3.7
+      - image: grokzen/redis-cluster:4.0.9
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.7-cluster-5:
+    docker:
+      - image: python:3.7
+      - image: grokzen/redis-cluster:5.0.4
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.8-cluster-3:
+    docker:
+      - image: python:3.8
+      - image: grokzen/redis-cluster:3.2.11
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.8-cluster-4:
+    docker:
+      - image: python:3.8
+      - image: grokzen/redis-cluster:4.0.9
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.8-cluster-5:
+    docker:
+      - image: python:3.8
+      - image: grokzen/redis-cluster:5.0.4
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
   python-3.5-client-3-hiredis:
     docker:
       - image: python:3.5
@@ -168,6 +282,66 @@ jobs:
   python-3.6-client-5-hiredis:
     docker:
       - image: python:3.6
+      - image: redis:5.0
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.7-client-3-hiredis:
+    docker:
+      - image: python:3.7
+      - image: redis:3
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.7-client-4-hiredis:
+    docker:
+      - image: python:3.7
+      - image: redis:4
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.7-client-5-hiredis:
+    docker:
+      - image: python:3.7
+      - image: redis:5.0
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.8-client-3-hiredis:
+    docker:
+      - image: python:3.8
+      - image: redis:3
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.8-client-4-hiredis:
+    docker:
+      - image: python:3.8
+      - image: redis:4
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: pytest tests/client/
+
+  python-3.8-client-5-hiredis:
+    docker:
+      - image: python:3.8
       - image: redis:5.0
     steps:
       - checkout
@@ -241,6 +415,72 @@ jobs:
       - run: sleep 10  # give the cluster some init time
       - run: pytest tests/cluster/
 
+  python-3.7-cluster-3-hiredis:
+    docker:
+      - image: python:3.7
+      - image: grokzen/redis-cluster:3.2.11
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.7-cluster-4-hiredis:
+    docker:
+      - image: python:3.7
+      - image: grokzen/redis-cluster:4.0.9
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.7-cluster-5-hiredis:
+    docker:
+      - image: python:3.7
+      - image: grokzen/redis-cluster:5.0.4
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.8-cluster-3-hiredis:
+    docker:
+      - image: python:3.8
+      - image: grokzen/redis-cluster:3.2.11
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.8-cluster-4-hiredis:
+    docker:
+      - image: python:3.8
+      - image: grokzen/redis-cluster:4.0.9
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
+  python-3.8-cluster-5-hiredis:
+    docker:
+      - image: python:3.8
+      - image: grokzen/redis-cluster:5.0.4
+    steps:
+      - checkout
+      - run: python -m pip install -r test_requirements.txt
+      - run: python -m pip install hiredis
+      - run: sleep 10  # give the cluster some init time
+      - run: pytest tests/cluster/
+
 workflows:
   version: 2
   run-jobs:
@@ -253,6 +493,14 @@ workflows:
       - python-3.6-client-4
       - python-3.6-client-5
 
+      - python-3.7-client-3
+      - python-3.7-client-4
+      - python-3.7-client-5
+
+      - python-3.8-client-3
+      - python-3.8-client-4
+      - python-3.8-client-5
+
       - python-3.5-cluster-3
       - python-3.5-cluster-4
       - python-3.5-cluster-5
@@ -260,6 +508,14 @@ workflows:
       - python-3.6-cluster-3
       - python-3.6-cluster-4
       - python-3.6-cluster-5
+
+      - python-3.7-cluster-3
+      - python-3.7-cluster-4
+      - python-3.7-cluster-5
+
+      - python-3.8-cluster-3
+      - python-3.8-cluster-4
+      - python-3.8-cluster-5
 
       - python-3.5-client-3-hiredis
       - python-3.5-client-4-hiredis
@@ -269,6 +525,14 @@ workflows:
       - python-3.6-client-4-hiredis
       - python-3.6-client-5-hiredis
 
+      - python-3.7-client-3-hiredis
+      - python-3.7-client-4-hiredis
+      - python-3.7-client-5-hiredis
+
+      - python-3.8-client-3-hiredis
+      - python-3.8-client-4-hiredis
+      - python-3.8-client-5-hiredis
+
       - python-3.5-cluster-3-hiredis
       - python-3.5-cluster-4-hiredis
       - python-3.5-cluster-5-hiredis
@@ -276,3 +540,11 @@ workflows:
       - python-3.6-cluster-3-hiredis
       - python-3.6-cluster-4-hiredis
       - python-3.6-cluster-5-hiredis
+
+      - python-3.7-cluster-3-hiredis
+      - python-3.7-cluster-4-hiredis
+      - python-3.7-cluster-5-hiredis
+
+      - python-3.8-cluster-3-hiredis
+      - python-3.8-cluster-4-hiredis
+      - python-3.8-cluster-5-hiredis

--- a/aredis/client.py
+++ b/aredis/client.py
@@ -1,6 +1,9 @@
 import asyncio
 import sys
-from asyncio.futures import CancelledError
+try:
+    from asyncio import CancelledError
+except ImportError:
+    from asyncio.futures import CancelledError
 
 from aredis.commands.cluster import ClusterCommandMixin
 from aredis.commands.connection import ClusterConnectionCommandMixin, ConnectionCommandMixin

--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -1,6 +1,9 @@
 import asyncio
 import threading
-from asyncio.futures import CancelledError
+try:
+    from asyncio import CancelledError
+except ImportError:
+    from asyncio.futures import CancelledError
 
 from aredis.exceptions import PubSubError, ConnectionError, TimeoutError
 from aredis.utils import (list_or_args,

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
     ext_modules=[
         Extension(name='aredis.speedups',
@@ -143,6 +145,6 @@ setup(
     # so even if a local contextvars module is installed,
     # the one from the standard library will be used.
     install_requires=[
-        'contextvars;python_version<"3.7"'
+        'contextvars;python_version<"3.9"'
     ]
 )


### PR DESCRIPTION
CancelledError from Python 3.7+ is move from futures subpackage to the root of asyncio package.