### PR TITLE
fix: Don't install contextvars on Python 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,6 @@ setup(
     # so even if a local contextvars module is installed,
     # the one from the standard library will be used.
     install_requires=[
-        'contextvars;python_version<"3.9"'
+        'contextvars;python_version<"3.7"'
     ]
 )


### PR DESCRIPTION
## Description
Don't install contextvars on Python 3.7+. This package has no effect on Python 3.7+ (contextvars are in the stdlib) and results in unnecessary dependencies. This looks like it was changed in 840ee435c9c41473b5127b77109d9627da766792