### PR TITLE
Fix #137: When cancelling a task, CancelledError exception is not pro…

### DIFF
--- a/aredis/client.py
+++ b/aredis/client.py
@@ -1,6 +1,9 @@
 import asyncio
 import sys
-from asyncio import CancelledError
+try:
+    from asyncio import CancelledError
+except ImportError:
+    from asyncio.futures import CancelledError
 
 from aredis.commands.cluster import ClusterCommandMixin
 from aredis.commands.connection import ClusterConnectionCommandMixin, ConnectionCommandMixin

--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -8,7 +8,7 @@ import sys
 import time
 import warnings
 import inspect
-from concurrent.futures import CancelledError
+from asyncio import CancelledError
 from io import BytesIO
 
 from aredis.exceptions import (ConnectionError, TimeoutError,

--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -8,7 +8,10 @@ import sys
 import time
 import warnings
 import inspect
-from asyncio import CancelledError
+try:
+    from asyncio import CancelledError
+except ImportError:
+    from asyncio.futures import CancelledError
 from io import BytesIO
 
 from aredis.exceptions import (ConnectionError, TimeoutError,

--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -1,9 +1,6 @@
 import asyncio
 import threading
-try:
-    from asyncio import CancelledError
-except ImportError:
-    from asyncio.futures import CancelledError
+from asyncio import CancelledError
 
 from aredis.exceptions import PubSubError, ConnectionError, TimeoutError
 from aredis.utils import (list_or_args,

--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -1,6 +1,9 @@
 import asyncio
 import threading
-from asyncio import CancelledError
+try:
+    from asyncio import CancelledError
+except ImportError:
+    from asyncio.futures import CancelledError
 
 from aredis.exceptions import PubSubError, ConnectionError, TimeoutError
 from aredis.utils import (list_or_args,


### PR DESCRIPTION
…pagated to client

## Description

1. re-raise the exception.
2. Using the exception from asyncio which is always defined, to be sure it is caught by callers.