### PR TITLE
Add an actual simple example!

### DIFF
--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -8,6 +8,18 @@ number of back-and-forth TCP packets between the client and server.
 
 Pipelines are quite simple to use:
 
+
+.. code-block:: python
+
+    async with await client.pipeline() as pipe:
+        await pipe.delete('bar')
+        await pipe.set('bar', 'foo')
+        await pipe.execute()  # needs to be called explicitly
+        
+        
+Here are more examples:
+
+
 .. code-block:: python
 
     >>> async def example(client):


### PR DESCRIPTION
The 'simple' example seemed to have every possible feature crammed in!

Aside from my conviction that the word 'simple' should really never be used in documentation (if something is simple then why are you documenting it?), my main difficulty here was trying to figure out where `async` and `await` are needed on the various statements.
i.e. if I'm just queueing up commands for execution, why do I need to await them?  And why do I need to await the call to `client.pipeline()`?  This is all quite verbose and certainly not simple.
Also I emphatically assummed that the `with` context manager would actually execute the pipeline upon exit, otherwise what is a context manager for??  (yes I've read the source and see that you can reuse a pipeline; I wouldn't have thought to do it this way but would have just created a new pipeline for a new transaction)

Anyhow hopefully this smaller example is correct and will be helpful to future readers of the documentation.
