### PR TITLE
optimize redis cluster readonly mode

### DIFF
--- a/aredis/client.py
+++ b/aredis/client.py
@@ -400,7 +400,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
                     # MOVED
                     node = self.connection_pool.get_master_node_by_slot(slot)
                 else:
-                    node = self.connection_pool.get_node_by_slot(slot)
+                    node = self.connection_pool.get_node_by_slot(slot, command)
                 r = self.connection_pool.get_connection_by_node(node)
 
             try:

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -494,7 +494,8 @@ class ClusterConnectionPool(ConnectionPool):
     def get_master_node_by_slot(self, slot):
         return self.nodes.slots[slot][0]
 
-    def get_node_by_slot(self, slot):
-        if self.readonly:
+    def get_node_by_slot(self, slot, command):
+        #prevent movederr exception, optimized read lookup speed
+        if self.readonly and command in ["GET", "GETBIT", "HGETALL", "HMGET", "HLEN", "LLEN", "LINDEX", "MGET"]:
             return random.choice(self.nodes.slots[slot])
         return self.get_master_node_by_slot(slot)

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -494,7 +494,7 @@ class ClusterConnectionPool(ConnectionPool):
     def get_master_node_by_slot(self, slot):
         return self.nodes.slots[slot][0]
 
-    def get_node_by_slot(self, slot, command):
+    def get_node_by_slot(self, slot, command=None):
         #prevent movederr exception, optimized read lookup speed
         if self.readonly and command in ["GET", "GETBIT", "HGETALL", "HMGET", "HLEN", "LLEN", "LINDEX", "MGET"]:
             return random.choice(self.nodes.slots[slot])


### PR DESCRIPTION
## Description

optimize cluster readonly mode by avoid MovedError in write-bound command.


### How to reproduce
redis environment:
- version: 5.0.6
- master-slave: 5:5

aredis connection pool settings:
- readonly=True
- reinitialize_steps=None

fuction optimzed:
- pool.py/get_node_by_slot

debugging application with vscode, when app invoke write command,  fuction `get_node_by_slot` will return random nodes in that slot when readonly is true.  this will cause MovedError exception(in write command like set, expire, setnx etc..) and cause cluster reinitialize,  consume cpu usage.


## 中文说明

aredis 集群模式在readonly设置为true的情况下，未对命令做读写区分，导致了在redis从节点上执行了写操作，触发MovedError异常，最后耗费大量cpu时间在reinitialize流程上， 在多主多从(5主5从及以上)的配置下，非常消耗cpu资源。
对readonly逻辑进行优化，读相关指令，可直接从slot对应主从中选择执行， 写相关指令，则直接返回主节点。