### PR TITLE
Fix bug: connection is already disconnected before idle check on cluster connection pool

### DIFF
--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -328,7 +328,10 @@ class ClusterConnectionPool(ConnectionPool):
                     and not connection.awaiting_response):
                 connection.disconnect()
                 node = connection.node
-                self._available_connections[node['name']].remove(connection)
+                try:
+                    self._available_connections[node['name']].remove(connection)
+                except ValueError:
+                    pass
                 self._created_connections_per_node[node['name']] -= 1
                 break
             await asyncio.sleep(self.idle_check_interval)


### PR DESCRIPTION
## Description

Fix bug that raises ValueError when connection is already disconnected before idle check on cluster connection pool.

https://github.com/NoneGG/aredis/issues/140#issuecomment-826156169