### PR TITLE
always reduce connection count when force disconnecting

### DIFF
--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -419,8 +419,8 @@ class ClusterConnectionPool(ConnectionPool):
         # discard connection with unread response
         if connection.awaiting_response:
             connection.disconnect()
-            # reduce node connection count in case of too many connection error raised
-            if self.max_connections_per_node and self._created_connections_per_node.get(connection.node['name']):
+            # reduce node connection count in case of too many connections error raised
+            if self._created_connections_per_node.get(connection.node['name']):
                 self._created_connections_per_node[connection.node['name']] -= 1
         else:
             self._available_connections.setdefault(connection.node["name"], []).append(connection)


### PR DESCRIPTION
I can't see any reason for that check on `self.max_connections_per_node` given that `count_all_num_connections` sums over all node connections when `max_connections_per_node == False`.
I was quickly running into the MaxConnections error when a single node was likely slow in it's response.  I was wondering why it went away when I experimented with setting `max_connections_per_node` in the config.