### PR TITLE
Fix connection basic query arguments

### DIFF
--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -33,7 +33,11 @@ def to_bool(value):
 URL_QUERY_ARGUMENT_PARSERS = {
     'stream_timeout': float,
     'connect_timeout': float,
-    'retry_on_timeout': to_bool
+    'retry_on_timeout': to_bool,
+    'max_connections': int,
+    'max_idle_time': int,
+    'idle_check_interval': int,
+    'reader_read_size': int
 }
 
 

--- a/tests/client/test_connection_pool.py
+++ b/tests/client/test_connection_pool.py
@@ -86,7 +86,7 @@ class TestConnectionPool:
         assert last_active_at == conn.last_active_at
         assert conn._writer is None and conn._reader is None
 
-
+    
 class TestConnectionPoolURLParsing:
     def test_defaults(self):
         pool = aredis.ConnectionPool.from_url('redis://localhost')
@@ -225,6 +225,50 @@ class TestConnectionPoolURLParsing:
             'Invalid value for `stream_timeout` in connection URL.',
         ]
 
+    def test_max_connections_querystring_option(self):
+        pool = aredis.ConnectionPool.from_url('redis://localhost?max_connections=32')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+            'max_connections': 32
+        }
+    
+    def test_max_idle_times_querystring_option(self):
+        pool = aredis.ConnectionPool.from_url('redis://localhost?max_idle_time=5')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+            'max_idle_time': 5
+        }
+
+    def test_idle_check_interval_querystring_option(self):
+        pool = aredis.ConnectionPool.from_url('redis://localhost?idle_check_interval=1')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+            'idle_check_interval': 1
+        }
+
+    def test_reader_read_size_querystring_option(self):
+        pool = aredis.ConnectionPool.from_url('redis://localhost?reader_read_size=65535')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+            'reader_read_size': 65535
+        }
+
     def test_extra_querystring_options(self):
         pool = aredis.ConnectionPool.from_url('redis://localhost?a=1&b=2')
         assert pool.connection_class == aredis.Connection
@@ -305,6 +349,50 @@ class TestConnectionPoolUnixSocketURLParsing:
             'path': '/socket',
             'db': 2,
             'password': None,
+        }
+
+    def test_max_connections_querystring_option(self):
+        pool = aredis.ConnectionPool.from_url('unix:///localhost?max_connections=32')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+            'max_connections': 32
+        }
+    
+    def test_max_idle_times_querystring_option(self):
+        pool = aredis.ConnectionPool.from_url('unix:///localhost?max_idle_time=5')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+            'max_idle_time': 5
+        }
+
+    def test_idle_check_interval_querystring_option(self):
+        pool = aredis.ConnectionPool.from_url('unix:///localhost?idle_check_interval=1')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+            'idle_check_interval': 1
+        }
+
+    def test_reader_read_size_querystring_option(self):
+        pool = aredis.ConnectionPool.from_url('unix:///localhost?reader_read_size=65535')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None,
+            'reader_read_size': 65535
         }
 
     def test_extra_querystring_options(self):


### PR DESCRIPTION
## Description

Hi guys.

This patch correctly cast the from_url method for the parameters:

- max_connections
- max_idle_time
- idle_check_interval
- reader_read_size

When assembling a connection string with these parameters, it is not cast before passing it to the ConnectionPool class. Example:

```python
import aredis

aredis.StrictRedis.from_url('redis://localhost:6379?max_connections=100&max_idle_time=5 ')
```

Out:
```
~/Documents/Projetos/crm/.venv/lib/python3.9/site-packages/aredis/pool.py in __init__(self, connection_class, max_connections, max_idle_time, idle_check_interval, **connection_kwargs)
    164         max_connections = max_connections or 2 ** 31
    165         if not isinstance(max_connections, int) or max_connections < 0:
--> 166             raise ValueError('"max_connections" must be a positive integer')
    167 
    168         self.connection_class = connection_class

ValueError: "max_connections" must be a positive integer
```