### PR TITLE
Don't open connection with loop for python 3.10

### DIFF
--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -593,11 +593,21 @@ class Connection(BaseConnection):
         self.socket_keepalive_options = socket_keepalive_options or {}
 
     async def _connect(self):
+        if LOOP_DEPRECATED:
+            connection = asyncio.open_connection(
+                host=self.host,
+                port=self.port,
+                ssl=self.ssl_context
+            )
+        else:
+            connection = asyncio.open_connection(
+                host=self.host,
+                port=self.port,
+                ssl=self.ssl_context,
+                loop=self.loop
+            )
         reader, writer = await exec_with_timeout(
-            asyncio.open_connection(host=self.host,
-                                    port=self.port,
-                                    ssl=self.ssl_context,
-                                    loop=self.loop),
+            connection,
             self._connect_timeout,
             loop=self.loop
         )

--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -652,10 +652,19 @@ class UnixDomainSocketConnection(BaseConnection):
         }
 
     async def _connect(self):
+        if LOOP_DEPRECATED:
+            connection = asyncio.open_unix_connection(
+                path=self.path,
+                ssl=self.ssl_context
+            )
+        else:
+            connection = asyncio.open_unix_connection(
+                path=self.path,
+                ssl=self.ssl_context,
+                loop=self.loop
+            )
         reader, writer = await exec_with_timeout(
-            asyncio.open_unix_connection(path=self.path,
-                                         ssl=self.ssl_context,
-                                         loop=self.loop),
+            connection,
             self._connect_timeout,
             loop=self.loop
         )


### PR DESCRIPTION
## Description

Make aredis not pass `loop` to asyncio function that don't accept it anymore.

https://docs.python.org/3.10/library/asyncio-stream.html#asyncio.open_connection
https://docs.python.org/3.10/library/asyncio-stream.html#asyncio.open_unix_connection

https://github.com/NoneGG/aredis/issues/207