### PR TITLE
Change imports from redis->aredis in docs

### DIFF
--- a/docs/source/pubsub.rst
+++ b/docs/source/pubsub.rst
@@ -6,7 +6,7 @@ for new messages. Creating a `PubSub` object is easy.
 
 .. code-block:: python
 
-    r = redis.StrictRedis(...)
+    r = aredis.StrictRedis(...)
     p = r.pubsub()
 
 Once a `PubSub` instance is created, channels and patterns can be subscribed

--- a/docs/source/scripting.rst
+++ b/docs/source/scripting.rst
@@ -16,7 +16,7 @@ it with the multiplier value and returns the result.
 
 .. code-block:: pycon
 
-    r = redis.StrictRedis()
+    r = aredis.StrictRedis()
     lua = """
     local value = redis.call('GET', KEYS[1])
     value = tonumber(value)
@@ -54,7 +54,7 @@ that points to a completely different Redis server.
 
 .. code-block:: python
 
-    r2 = redis.StrictRedis('redis2.example.com')
+    r2 = aredis.StrictRedis('redis2.example.com')
     await r2.set('foo', 3)
     multiply.execute(keys=['foo'], args=[5], client=r2)
     # 15

--- a/docs/source/sentinel.rst
+++ b/docs/source/sentinel.rst
@@ -10,7 +10,7 @@ Sentinel connection to discover the master and slaves network addresses:
 
 .. code-block:: python
 
-    from redis.sentinel import Sentinel
+    from aredis.sentinel import Sentinel
     sentinel = Sentinel([('localhost', 26379)], stream_timeout=0.1)
     await sentinel.discover_master('mymaster')
     # ('127.0.0.1', 6379)


### PR DESCRIPTION
## Description

Minor tweaks to fix some dangling `import redis` instead of `import aredis` in the doc examples.
