### PR TITLE
Don't pass loop arg to asyncio.open_connection

### DIFF
--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -596,8 +596,7 @@ class Connection(BaseConnection):
         reader, writer = await exec_with_timeout(
             asyncio.open_connection(host=self.host,
                                     port=self.port,
-                                    ssl=self.ssl_context,
-                                    loop=self.loop),
+                                    ssl=self.ssl_context),
             self._connect_timeout,
             loop=self.loop
         )


### PR DESCRIPTION
Fix #212. Required for Python 3.10+.

## Description

Please describe your pull request.

NOTE: All patches should be made against master!

If it fixes a bug or resolves a feature request be sure to link to that issue.
It is appreciated if you can make an issue before making a pull request.