### PR TITLE
Do not pass loop if Python >=3.10

### DIFF
--- a/aredis/utils.py
+++ b/aredis/utils.py
@@ -12,6 +12,7 @@ except Exception:
     pass
 
 LOOP_DEPRECATED = sys.version_info >= (3, 8)
+LOOP_DEPRECATED_OPEN_CONNECTION=sys.version_info >= (3, 10)
 
 
 def b(x):


### PR DESCRIPTION
## Description

This fixed the issue https://github.com/NoneGG/aredis/issues/220 : the parameter loop in Python>=3.10 is no longer supported for asyncio.open_connection . This patch adds a check for it.
