### PR TITLE
Project engineering review

### DIFF
--- a/aredis/cache.py
+++ b/aredis/cache.py
@@ -175,13 +175,16 @@ class BasicCache:
         Deletes cache according to pattern in redis,
         delete `count` keys each time
         """
-        cursor = '0'
+        cursor = 0
         count_deleted = 0
-        while cursor != 0:
+        while True:
             cursor, identities = await self.client.scan(
                 cursor=cursor, match=pattern, count=count
             )
-            count_deleted += await self.client.delete(*identities)
+            if identities:
+                count_deleted += await self.client.delete(*identities)
+            if cursor == 0:
+                break
         return count_deleted
 
     async def exist(self, key, param=None):

--- a/aredis/commands/transaction.py
+++ b/aredis/commands/transaction.py
@@ -33,8 +33,7 @@ class TransactionCommandMixin:
                 except WatchError:
                     if watch_delay is not None and watch_delay > 0:
                         await asyncio.sleep(
-                            watch_delay,
-                            loop=self.connection_pool.loop
+                            watch_delay
                         )
                     continue
 
@@ -75,7 +74,6 @@ class ClusterTransactionCommandMixin(TransactionCommandMixin):
                 except WatchError:
                     if watch_delay is not None and watch_delay > 0:
                         await asyncio.sleep(
-                            watch_delay,
-                            loop=self.connection_pool.loop
+                            watch_delay
                         )
                     continue

--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -416,7 +416,7 @@ class BaseConnection:
         except aredis.compat.CancelledError:
             raise
         except Exception as exc:
-            raise ConnectionError()
+            raise ConnectionError() from exc
         # run any user callbacks. right now the only internal callback
         # is for pubsub channel/pattern resubscription
         for callback in self._connect_callbacks:
@@ -593,13 +593,23 @@ class Connection(BaseConnection):
         self.socket_keepalive_options = socket_keepalive_options or {}
 
     async def _connect(self):
+        if LOOP_DEPRECATED:
+            conn_coro = asyncio.open_connection(
+                host=self.host,
+                port=self.port,
+                ssl=self.ssl_context,
+            )
+        else:
+            conn_coro = asyncio.open_connection(
+                host=self.host,
+                port=self.port,
+                ssl=self.ssl_context,
+                loop=self.loop,
+            )
         reader, writer = await exec_with_timeout(
-            asyncio.open_connection(host=self.host,
-                                    port=self.port,
-                                    ssl=self.ssl_context,
-                                    loop=self.loop),
+            conn_coro,
             self._connect_timeout,
-            loop=self.loop
+            loop=self.loop,
         )
         self._reader = reader
         self._writer = writer
@@ -642,12 +652,21 @@ class UnixDomainSocketConnection(BaseConnection):
         }
 
     async def _connect(self):
+        if LOOP_DEPRECATED:
+            conn_coro = asyncio.open_unix_connection(
+                path=self.path,
+                ssl=self.ssl_context,
+            )
+        else:
+            conn_coro = asyncio.open_unix_connection(
+                path=self.path,
+                ssl=self.ssl_context,
+                loop=self.loop,
+            )
         reader, writer = await exec_with_timeout(
-            asyncio.open_unix_connection(path=self.path,
-                                         ssl=self.ssl_context,
-                                         loop=self.loop),
+            conn_coro,
             self._connect_timeout,
-            loop=self.loop
+            loop=self.loop,
         )
         self._reader = reader
         self._writer = writer

--- a/aredis/lock.py
+++ b/aredis/lock.py
@@ -119,7 +119,7 @@ class Lock:
                 return False
             if stop_trying_at is not None and mod_time.time() > stop_trying_at:
                 return False
-            await asyncio.sleep(sleep, loop=self.redis.connection_pool.loop)
+            await asyncio.sleep(sleep)
 
     async def do_acquire(self, token):
         if self.timeout:
@@ -347,7 +347,7 @@ class ClusterLock(LuaLock):
                     return False
             if not blocking or mod_time.time() > stop_trying_at:
                 return False
-            await asyncio.sleep(sleep, loop=self.redis.connection_pool.loop)
+            await asyncio.sleep(sleep)
 
     async def do_release(self, expected_token):
         await super(ClusterLock, self).do_release(expected_token)

--- a/aredis/pipeline.py
+++ b/aredis/pipeline.py
@@ -200,7 +200,7 @@ class BasePipeline:
                     # typing.Awaitable is not available in Python3.5
                     # so use inspect.isawaitable instead
                     # according to issue https://github.com/NoneGG/aredis/issues/77
-                    if inspect.isawaitable(response):
+                    if inspect.isawaitable(r):
                         r = await r
             data.append(r)
         return data

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -174,6 +174,32 @@ class ConnectionPool:
 
         self.reset()
 
+    def _schedule_idle_check(self, connection):
+        """
+        Schedule an idle-connection reaper task on the right loop.
+
+        We avoid asyncio.ensure_future() without an explicit loop because it
+        can attach to an unexpected loop (or fail) on modern asyncio.
+        """
+        coro = self.disconnect_on_idle_time_exceeded(connection)
+        try:
+            if self.loop is not None:
+                task = self.loop.create_task(coro)
+            else:
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    loop = asyncio.get_event_loop()
+                task = loop.create_task(coro)
+        except Exception:
+            # If we can't schedule a background task (e.g. no event loop),
+            # silently skip idle reaping. The connection will still be cleaned
+            # up when the pool is disconnected or the process exits.
+            return
+
+        self._idle_check_tasks.add(task)
+        task.add_done_callback(lambda t: self._idle_check_tasks.discard(t))
+
     def __repr__(self):
         return '{}<{}>'.format(
             type(self).__name__,
@@ -199,6 +225,7 @@ class ConnectionPool:
         self._available_connections = []
         self._in_use_connections = set()
         self._check_lock = threading.Lock()
+        self._idle_check_tasks = set()
 
     def _checkpid(self):
         if self.pid != os.getpid():
@@ -227,8 +254,7 @@ class ConnectionPool:
         self._created_connections += 1
         connection = self.connection_class(**self.connection_kwargs)
         if self.max_idle_time > self.idle_check_interval > 0:
-            # do not await the future
-            asyncio.ensure_future(self.disconnect_on_idle_time_exceeded(connection))
+            self._schedule_idle_check(connection)
         return connection
 
     def release(self, connection):
@@ -246,11 +272,16 @@ class ConnectionPool:
 
     def disconnect(self):
         """Closes all connections in the pool"""
-        all_conns = chain(self._available_connections,
-                          self._in_use_connections)
+        for task in list(self._idle_check_tasks):
+            task.cancel()
+        self._idle_check_tasks.clear()
+
+        all_conns = list(chain(self._available_connections, self._in_use_connections))
         for connection in all_conns:
             connection.disconnect()
-            self._created_connections -= 1
+        self._available_connections = []
+        self._in_use_connections = set()
+        self._created_connections = 0
 
 
 class ClusterConnectionPool(ConnectionPool):
@@ -301,6 +332,7 @@ class ClusterConnectionPool(ConnectionPool):
         self.readonly = readonly
         self.max_idle_time = max_idle_time
         self.idle_check_interval = idle_check_interval
+        self.loop = self.connection_kwargs.get('loop')
         self.reset()
 
         if "stream_timeout" not in self.connection_kwargs:
@@ -328,7 +360,12 @@ class ClusterConnectionPool(ConnectionPool):
                     and not connection.awaiting_response):
                 connection.disconnect()
                 node = connection.node
-                self._available_connections[node['name']].remove(connection)
+                conn_list = self._available_connections.get(node['name'])
+                if conn_list is not None:
+                    try:
+                        conn_list.remove(connection)
+                    except ValueError:
+                        pass
                 self._created_connections_per_node[node['name']] -= 1
                 break
             await asyncio.sleep(self.idle_check_interval)
@@ -340,6 +377,7 @@ class ClusterConnectionPool(ConnectionPool):
         self._available_connections = {}  # Dict(Node, List)
         self._in_use_connections = {}  # Dict(Node, Set)
         self._check_lock = threading.Lock()
+        self._idle_check_tasks = set()
         self.initialized = False
 
     def _checkpid(self):
@@ -398,8 +436,7 @@ class ClusterConnectionPool(ConnectionPool):
         # Must store node in the connection to make it eaiser to track
         connection.node = node
         if self.max_idle_time > self.idle_check_interval > 0:
-            # do not await the future
-            asyncio.ensure_future(self.disconnect_on_idle_time_exceeded(connection))
+            self._schedule_idle_check(connection)
         return connection
 
     def release(self, connection):
@@ -427,14 +464,21 @@ class ClusterConnectionPool(ConnectionPool):
 
     def disconnect(self):
         """Closes all connectins in the pool"""
+        for task in list(self._idle_check_tasks):
+            task.cancel()
+        self._idle_check_tasks.clear()
+
         all_conns = chain(
             self._available_connections.values(),
             self._in_use_connections.values(),
         )
-
         for node_connections in all_conns:
-            for connection in node_connections:
+            for connection in list(node_connections):
                 connection.disconnect()
+
+        self._available_connections = {}
+        self._in_use_connections = {}
+        self._created_connections_per_node = {}
 
     def count_all_num_connections(self, node):
         if self.max_connections_per_node:

--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import threading
 
 from aredis.compat import CancelledError
@@ -324,10 +325,7 @@ class PubSubWorkerThread(threading.Thread):
         if self.loop:
             unsubscribed = asyncio.run_coroutine_threadsafe(self.pubsub.unsubscribe(), self.loop)
             punsubscribed = asyncio.run_coroutine_threadsafe(self.pubsub.punsubscribe(), self.loop)
-            asyncio.wait(
-                [unsubscribed, punsubscribed],
-                loop=self.loop
-            )
+            concurrent.futures.wait([unsubscribed, punsubscribed])
 
 
 class ClusterPubSub(PubSub):


### PR DESCRIPTION
Fixes critical bugs and modernizes asyncio usage for improved robustness and compatibility.

This PR addresses several P0 issues identified in the project, including:
- Removing deprecated `loop=` parameters from asyncio calls to ensure compatibility with Python 3.8+.
- Correcting the `await` logic for asynchronous callbacks in pipelines.
- Fixing a potential infinite loop or non-execution bug in `Cache.delete_pattern`'s SCAN cursor handling.
- Enhancing exception chaining in connection errors to preserve root causes.
- Improving the robustness of connection pool idle-check background tasks by ensuring proper scheduling and cancellation.
- Making connection pool `disconnect()` operations more idempotent.
- Updating `PubSubWorkerThread` to use `concurrent.futures.wait` instead of deprecated `asyncio.wait(loop=...)`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9acfe74a-9a36-48df-9240-b535e77cb62b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9acfe74a-9a36-48df-9240-b535e77cb62b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes asyncio integration and fixes several correctness issues across cache, pipeline, connections, pools, and pubsub.
> 
> - Updates asyncio calls to avoid deprecated `loop=` parameters (`asyncio.sleep`, `open_connection`, `open_unix_connection`, timeouts, thread waits) gated by `LOOP_DEPRECATED`; uses `concurrent.futures.wait` in `PubSubWorkerThread.stop`
> - Fixes `Cache.delete_pattern` SCAN loop: start `cursor=0`, iterate until `cursor==0`, and guard deletes when no identities
> - Corrects pipeline response handling: await callbacks only when `inspect.isawaitable(r)`
> - Enhances error context: `Connection.connect()` now raises `ConnectionError` with exception chaining (`from exc`)
> - Connection pool robustness: schedule idle-reaper tasks on the appropriate loop, track/cancel them on `disconnect()`, and fully reset internal state; make cluster pool variants consistent and resilient to missing entries during removal
> - Removes deprecated loop arguments in transaction retry sleeps and `Lock` sleep; minor cleanups to avoid negative counters and ensure idempotent disconnect behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61f0b8a6fae583a7b6fc0a53d09b4b42bf964dac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->